### PR TITLE
Add timeout to worker start

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -420,7 +420,6 @@ func (w *Worker) Close() {
 	if w.child != nil {
 		w.child.Process.Signal(syscall.SIGTERM)
 		w.child.Process.Signal(os.Kill)
-		w.child = nil
 	}
 
 	// Close the Channel instance.


### PR DESCRIPTION
Fixes #5 

This is more hacky than I'd like but I'm not sure if there's a better way to ensure that the worker doesn't emit the running event before the `Once` handler is registered. If we could somehow add the handler atomically to the channel during construction, that would probably be optimal.

Also fixes a data race encountered when closing a worker on a separate thread.