### PR TITLE
feat: expose producer and transport field of router with methods

### DIFF
--- a/router.go
+++ b/router.go
@@ -232,16 +232,46 @@ func (router *Router) Dump() (data *RouterDump, err error) {
 	return
 }
 
-// GetProducers returns available producers on the router.
-func (router *Router) GetProducers() sync.Map {
-	router.logger.Debug("GetProducers()")
-	return router.producers
+// Producers returns available producers on the router.
+func (router *Router) Producers() []*Producer {
+	router.logger.Debug("Producers()")
+	producers := make([]*Producer, 0)
+	router.producers.Range(func(key, value interface{}) bool {
+		producer, ok := value.(*Producer)
+		if ok {
+			producers = append(producers, producer)
+		}
+		return true
+	})
+	return producers
 }
 
-// GetTransports returns available transports on the router.
-func (router *Router) GetTransports() sync.Map {
-	router.logger.Debug("GetTransports()")
-	return router.transports
+// Producers returns available producers on the router.
+func (router *Router) DataProducers() []*DataProducer {
+	router.logger.Debug("DataProducers()")
+	dataProducers := make([]*DataProducer, 0)
+	router.dataProducers.Range(func(key, value interface{}) bool {
+		dataProducer, ok := value.(*DataProducer)
+		if ok {
+			dataProducers = append(dataProducers, dataProducer)
+		}
+		return true
+	})
+	return dataProducers
+}
+
+// Transports returns available transports on the router.
+func (router *Router) Transports() []*Transport {
+	router.logger.Debug("Transports()")
+	transports := make([]*Transport, 0)
+	router.transports.Range(func(key, value interface{}) bool {
+		transport, ok := value.(*Transport)
+		if ok {
+			transports = append(transports, transport)
+		}
+		return true
+	})
+	return transports
 }
 
 /**

--- a/router.go
+++ b/router.go
@@ -232,6 +232,18 @@ func (router *Router) Dump() (data *RouterDump, err error) {
 	return
 }
 
+// GetProducers returns available producers on the router.
+func (router *Router) GetProducers() sync.Map {
+	router.logger.Debug("GetProducers()")
+	return router.producers
+}
+
+// GetTransports returns available transports on the router.
+func (router *Router) GetTransports() sync.Map {
+	router.logger.Debug("GetTransports()")
+	return router.transports
+}
+
 /**
  * Create a WebRtcTransport.
  */

--- a/router.go
+++ b/router.go
@@ -261,11 +261,11 @@ func (router *Router) DataProducers() []*DataProducer {
 }
 
 // Transports returns available transports on the router.
-func (router *Router) Transports() []*Transport {
+func (router *Router) Transports() []ITransport {
 	router.logger.Debug("Transports()")
-	transports := make([]*Transport, 0)
+	transports := make([]ITransport, 0)
 	router.transports.Range(func(key, value interface{}) bool {
-		transport, ok := value.(*Transport)
+		transport, ok := value.(ITransport)
 		if ok {
 			transports = append(transports, transport)
 		}


### PR DESCRIPTION
It is important to have access to  producers and transports of a router.
So I added method to access the producers and transports field.