### PR TITLE
fix: ProfileId comparisons should dereference the *uint8

### DIFF
--- a/ortc.go
+++ b/ortc.go
@@ -877,9 +877,17 @@ func matchCodecs(aCodec *RtpCodecParameters, bCodec *RtpCodecCapability, options
 
 	case "video/vp9":
 		if options.strict {
-			aParameters, bParameters := aCodec.Parameters, bCodec.Parameters
+			aProfileId := uint8(0)
+			if aCodec.Parameters.ProfileId != nil {
+				aProfileId = *aCodec.Parameters.ProfileId
+			}
 
-			if aParameters.ProfileId != bParameters.ProfileId {
+			bProfileId := uint8(0)
+			if bCodec.Parameters.ProfileId != nil {
+				bProfileId = *bCodec.Parameters.ProfileId
+			}
+
+			if aProfileId != bProfileId {
 				return false
 			}
 		}


### PR DESCRIPTION
Since ProfileId was made a pointer in commit 6d4e2f3cd086ceb91dcc931546fb0c512ba003b8, other uses of this should be adjusted to avoid comparing the pointer itself.

This follows the reference implementation in mediasoup: https://github.com/versatica/mediasoup/blob/a0485562fb89cf82b4020eae87182921d89b9efc/node/src/ortc.ts#L1505