### PR TITLE
fix: PacketizationMode should be *uint8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ var consumerDeviceCapabilities = mediasoup.RtpCapabilities{
 			Parameters: mediasoup.RtpCodecSpecificParameters{
 				RtpParameter: h264.RtpParameter{
 					LevelAsymmetryAllowed: 1,
-					PacketizationMode:     1,
+					PacketizationMode:     Uint8(1),
 					ProfileLevelId:        "4d0032",
 				},
 			},
@@ -115,7 +115,7 @@ func main() {
 				Parameters: mediasoup.RtpCodecSpecificParameters{
 					RtpParameter: h264.RtpParameter{
 						LevelAsymmetryAllowed: 1,
-						PacketizationMode:     1,
+						PacketizationMode:     Uint8(1),
 						ProfileLevelId:        "4d0032",
 					},
 				},
@@ -146,7 +146,7 @@ func main() {
 					ClockRate:   90000,
 					Parameters: mediasoup.RtpCodecSpecificParameters{
 						RtpParameter: h264.RtpParameter{
-							PacketizationMode: 1,
+							PacketizationMode: Uint8(1),
 							ProfileLevelId:    "4d0032",
 						},
 					},

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -40,7 +40,7 @@ func (suite *ConsumerTestingSuite) SetupTest() {
 			Parameters: RtpCodecSpecificParameters{
 				RtpParameter: h264.RtpParameter{
 					LevelAsymmetryAllowed: 1,
-					PacketizationMode:     1,
+					PacketizationMode:     Uint8(1),
 					ProfileLevelId:        "4d0032",
 				},
 			},
@@ -64,7 +64,7 @@ func (suite *ConsumerTestingSuite) SetupTest() {
 				Parameters: RtpCodecSpecificParameters{
 					RtpParameter: h264.RtpParameter{
 						LevelAsymmetryAllowed: 1,
-						PacketizationMode:     1,
+						PacketizationMode:     Uint8(1),
 						ProfileLevelId:        "4d0032",
 					},
 				},
@@ -244,7 +244,7 @@ func (suite *ConsumerTestingSuite) TestTransportConsume_Succeeds() {
 		PayloadType: 103,
 		Parameters: RtpCodecSpecificParameters{
 			RtpParameter: h264.RtpParameter{
-				PacketizationMode: 1,
+				PacketizationMode: Uint8(1),
 				ProfileLevelId:    "4d0032",
 			},
 		},
@@ -297,7 +297,7 @@ func (suite *ConsumerTestingSuite) TestTransportConsume_Succeeds() {
 		PayloadType: 103,
 		Parameters: RtpCodecSpecificParameters{
 			RtpParameter: h264.RtpParameter{
-				PacketizationMode: 1,
+				PacketizationMode: Uint8(1),
 				ProfileLevelId:    "4d0032",
 			},
 		},
@@ -472,7 +472,7 @@ func (suite *ConsumerTestingSuite) TestConsumerDump() {
 	suite.Equal(90000, data.RtpParameters.Codecs[0].ClockRate)
 	suite.Empty(data.RtpParameters.Codecs[0].Channels)
 	suite.Equal(h264.RtpParameter{
-		PacketizationMode: 1,
+		PacketizationMode: Uint8(1),
 		ProfileLevelId:    "4d0032",
 	}, data.RtpParameters.Codecs[0].Parameters.RtpParameter)
 	suite.EqualValues([]RtcpFeedback{

--- a/examples/app/main.go
+++ b/examples/app/main.go
@@ -27,7 +27,7 @@ var consumerDeviceCapabilities = mediasoup.RtpCapabilities{
 			Parameters: mediasoup.RtpCodecSpecificParameters{
 				RtpParameter: h264.RtpParameter{
 					LevelAsymmetryAllowed: 1,
-					PacketizationMode:     1,
+					PacketizationMode:     Uint8(1),
 					ProfileLevelId:        "4d0032",
 				},
 			},
@@ -89,7 +89,7 @@ func main() {
 				Parameters: mediasoup.RtpCodecSpecificParameters{
 					RtpParameter: h264.RtpParameter{
 						LevelAsymmetryAllowed: 1,
-						PacketizationMode:     1,
+						PacketizationMode:     Uint8(1),
 						ProfileLevelId:        "4d0032",
 					},
 				},
@@ -120,7 +120,7 @@ func main() {
 					ClockRate:   90000,
 					Parameters: mediasoup.RtpCodecSpecificParameters{
 						RtpParameter: h264.RtpParameter{
-							PacketizationMode: 1,
+							PacketizationMode: Uint8(1),
 							ProfileLevelId:    "4d0032",
 						},
 					},

--- a/h264/h264profile.go
+++ b/h264/h264profile.go
@@ -227,7 +227,7 @@ func IsSameProfile(profileLevelIdStr1, profileLevelIdStr2 string) bool {
 }
 
 type RtpParameter struct {
-	PacketizationMode     uint8  `json:"packetization-mode,omitempty"`
+	PacketizationMode     *uint8 `json:"packetization-mode,omitempty"`
 	ProfileLevelId        string `json:"profile-level-id,omitempty"`
 	LevelAsymmetryAllowed uint8  `json:"level-asymmetry-allowed,omitempty"`
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -87,7 +87,7 @@ func CreateRouter(workers ...*Worker) *Router {
 				Parameters: RtpCodecSpecificParameters{
 					RtpParameter: h264.RtpParameter{
 						LevelAsymmetryAllowed: 1,
-						PacketizationMode:     1,
+						PacketizationMode:     Uint8(1),
 						ProfileLevelId:        "4d0032",
 					},
 				},
@@ -154,7 +154,7 @@ func CreateH264Producer(tranpsort ITransport) *Producer {
 					ClockRate:   90000,
 					Parameters: RtpCodecSpecificParameters{
 						RtpParameter: h264.RtpParameter{
-							PacketizationMode: 1,
+							PacketizationMode: Uint8(1),
 							ProfileLevelId:    "4d0032",
 						},
 					},

--- a/ortc.go
+++ b/ortc.go
@@ -857,11 +857,21 @@ func matchCodecs(aCodec *RtpCodecParameters, bCodec *RtpCodecCapability, options
 
 	case "video/h264":
 		if options.strict {
-			aParameters, bParameters := aCodec.Parameters, bCodec.Parameters
+			aPacketizationMode := uint8(0)
+			if aCodec.Parameters.PacketizationMode != nil {
+				aPacketizationMode = *aCodec.Parameters.PacketizationMode
+			}
 
-			if aParameters.PacketizationMode != bParameters.PacketizationMode {
+			bPacketizationMode := uint8(0)
+			if bCodec.Parameters.PacketizationMode != nil {
+				bPacketizationMode = *bCodec.Parameters.PacketizationMode
+			}
+
+			if aPacketizationMode != bPacketizationMode {
 				return false
 			}
+
+			aParameters, bParameters := aCodec.Parameters, bCodec.Parameters
 
 			selectedProfileLevelId, err := h264.GenerateProfileLevelIdForAnswer(
 				aParameters.RtpParameter, bParameters.RtpParameter)

--- a/producer_test.go
+++ b/producer_test.go
@@ -36,7 +36,7 @@ func (suite *ProducerTestingSuite) SetupTest() {
 			Parameters: RtpCodecSpecificParameters{
 				RtpParameter: h264.RtpParameter{
 					LevelAsymmetryAllowed: 1,
-					PacketizationMode:     1,
+					PacketizationMode:     Uint8(1),
 					ProfileLevelId:        "4d0032",
 				},
 			},
@@ -170,7 +170,7 @@ func (suite *ProducerTestingSuite) TestWebRtcTransportProduce_TypeError() {
 					ClockRate:   90000,
 					Parameters: RtpCodecSpecificParameters{
 						RtpParameter: h264.RtpParameter{
-							PacketizationMode: 1,
+							PacketizationMode: Uint8(1),
 							ProfileLevelId:    "4d0032",
 						},
 					},
@@ -200,7 +200,7 @@ func (suite *ProducerTestingSuite) TestWebRtcTransportProduce_TypeError() {
 					ClockRate:   90000,
 					Parameters: RtpCodecSpecificParameters{
 						RtpParameter: h264.RtpParameter{
-							PacketizationMode: 1,
+							PacketizationMode: Uint8(1),
 							ProfileLevelId:    "4d0032",
 						},
 					},
@@ -254,7 +254,7 @@ func (suite *ProducerTestingSuite) TestWebRtcTransportProduce_UnsupportedError()
 					ClockRate:   90000,
 					Parameters: RtpCodecSpecificParameters{
 						RtpParameter: h264.RtpParameter{
-							PacketizationMode: 1,
+							PacketizationMode: Uint8(1),
 							ProfileLevelId:    "CHICKEN",
 						},
 					},
@@ -312,7 +312,7 @@ func (suite *ProducerTestingSuite) TestWebRtcTransportProduce_WithAlreadyUsedMID
 					ClockRate:   90000,
 					Parameters: RtpCodecSpecificParameters{
 						RtpParameter: h264.RtpParameter{
-							PacketizationMode: 1,
+							PacketizationMode: Uint8(1),
 							ProfileLevelId:    "4d0032",
 						},
 					},
@@ -382,7 +382,7 @@ func (suite *ProducerTestingSuite) TestProduerDump_Succeeds() {
 	suite.Empty(data.RtpParameters.Codecs[0].Channels)
 	suite.Equal(RtpCodecSpecificParameters{
 		RtpParameter: h264.RtpParameter{
-			PacketizationMode: 1,
+			PacketizationMode: Uint8(1),
 			ProfileLevelId:    "4d0032",
 		},
 	}, data.RtpParameters.Codecs[0].Parameters)

--- a/router_test.go
+++ b/router_test.go
@@ -29,7 +29,7 @@ var testRouterMediaCodecs = []*RtpCodecCapability{
 		Parameters: RtpCodecSpecificParameters{
 			RtpParameter: h264.RtpParameter{
 				LevelAsymmetryAllowed: 1,
-				PacketizationMode:     1,
+				PacketizationMode:     Uint8(1),
 				ProfileLevelId:        "4d0032",
 			},
 		},

--- a/utils.go
+++ b/utils.go
@@ -21,6 +21,10 @@ func Bool(b bool) *bool {
 	return &b
 }
 
+func Uint8(v uint8) *uint8 {
+	return &v
+}
+
 func generateRandomNumber() uint32 {
 	return uint32(rand.Int63n(900000000)) + 100000000
 }


### PR DESCRIPTION
Related: https://github.com/jiyeyuran/mediasoup-go/issues/24

Like `RtpCodecSpecificParameters.ProfileId`,
there is `h264.RtpParameter.PacketizationMode`.

This value is optional, so it can be in 3 states:
* Undefined.
* Defined, with value 0.
* Defined, with value 1.

So it's more correct that the variable is made optional, as a pointer.

This adds a new function `Uint8()` to make assignments easy.

Note that starting from Go 1.18 with generics, all util pointer functions can be replaced with a single one like this:

```
func Ptr[T any](v T) *T {
	return &v
}
```

But mediasoup-go is using Go 1.13, so for now the util functions are needed.