### PR TITLE
fix: PreferredPayloadType should be "omitempty" (revert d330f7b)

### DIFF
--- a/rtp_parameters.go
+++ b/rtp_parameters.go
@@ -49,7 +49,7 @@ type RtpCodecCapability struct {
 	MimeType string `json:"mimeType"`
 
 	// PreferredPayloadType is the preferred RTP payload type.
-	PreferredPayloadType byte `json:"preferredPayloadType"`
+	PreferredPayloadType byte `json:"preferredPayloadType,omitempty"`
 
 	// ClockRate is the codec clock rate expressed in Hertz.
 	ClockRate int `json:"clockRate"`


### PR DESCRIPTION
This reverts the change that I wrongly proposed in commit https://github.com/jiyeyuran/mediasoup-go/commit/d330f7bb5ed5b48d0cc0c65e8602e005076a232b

PreferredPayloadType was OK being "omitempty", because for the purposes of mediasoup, a PayloadType == 0 is used as unset value. So, better to restore "omitempty" for this field.

----

Note: *Technically*, the PayloadType `0` is a valid one, corresponding
to PCMU: https://en.wikipedia.org/wiki/RTP_payload_formats

For example, Chrome offers PCMU in its WebRTC SDP Offer:

    m=audio 9 UDP/TLS/RTP/SAVPF 63 111 9 0 8 13 110 126
    a=rtpmap:0 PCMU/8000

So if users need it, maybe in the future PayloadType should be made an optional field (pointer)... but if there is no requests for this, I don't think it's worth changing it for now.