### PR TITLE
Fix goroutine leaks in tests

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -62,9 +62,13 @@ var consumerDeviceCapabilities = RtpCapabilities{
 }
 
 func CreateRouter(workers ...*Worker) *Router {
-	myworker := worker
+	var myworker *Worker
+	closeWithRouter := false
 	if len(workers) > 0 && workers[0] != nil {
 		myworker = workers[0]
+	} else {
+		myworker = CreateTestWorker()
+		closeWithRouter = true
 	}
 
 	router, err := myworker.CreateRouter(RouterOptions{
@@ -97,6 +101,11 @@ func CreateRouter(workers ...*Worker) *Router {
 	if err != nil {
 		panic(err)
 	}
+
+	if closeWithRouter {
+		router.OnClose(myworker.Close)
+	}
+
 	return router
 }
 

--- a/pipe_transport_test.go
+++ b/pipe_transport_test.go
@@ -25,8 +25,8 @@ type PipeTransportTestingSuite struct {
 }
 
 func (suite *PipeTransportTestingSuite) SetupTest() {
-	suite.router1 = CreateRouter(CreateTestWorker())
-	suite.router2 = CreateRouter(CreateTestWorker())
+	suite.router1 = CreateRouter()
+	suite.router2 = CreateRouter()
 
 	suite.transport1, _ = suite.router1.CreateWebRtcTransport(WebRtcTransportOptions{
 		ListenIps: []TransportListenIp{
@@ -625,8 +625,8 @@ func (suite *PipeTransportTestingSuite) TestDataProducerCloseIsTransmittedToPipe
 func (suite *PipeTransportTestingSuite) TestPipeToRouter() {
 	t := suite.T()
 	t.Run(`router.pipeToRouter() called twice generates a single PipeTransport pair`, func(t *testing.T) {
-		routerA := CreateRouter(CreateTestWorker())
-		routerB := CreateRouter(CreateTestWorker())
+		routerA := CreateRouter()
+		routerB := CreateRouter()
 		defer routerA.Close()
 		defer routerB.Close()
 
@@ -665,8 +665,8 @@ func (suite *PipeTransportTestingSuite) TestPipeToRouter() {
 	})
 
 	t.Run("router.pipeToRouter() called in two Routers passing one to each other as argument generates a single a single PipeTransport pair", func(t *testing.T) {
-		routerA := CreateRouter(CreateTestWorker())
-		routerB := CreateRouter(CreateTestWorker())
+		routerA := CreateRouter()
+		routerB := CreateRouter()
 		defer routerB.Close()
 
 		transportA, _ := routerA.CreateWebRtcTransport(WebRtcTransportOptions{

--- a/router_test.go
+++ b/router_test.go
@@ -86,6 +86,8 @@ func TestRouterClose_Succeeds(t *testing.T) {
 
 	onObserverClose.ExpectCalled()
 	assert.True(t, router.Closed())
+
+	worker.Close()
 }
 
 func TestRouterEmitsWorkCloseIfWorkerIsClosed(t *testing.T) {

--- a/webrtc_server_test.go
+++ b/webrtc_server_test.go
@@ -122,6 +122,7 @@ func TestWebRtcServerCloseSucceeds(t *testing.T) {
 	onObserverClose := NewMockFunc(t)
 	webRtcServer.Observer().Once("close", onObserverClose.Fn())
 	webRtcServer.Close()
+	worker.Close()
 
 	onObserverClose.ExpectCalledTimes(1)
 	assert.True(t, webRtcServer.Closed())
@@ -229,6 +230,8 @@ func TestRouterCreateWebRtcTransportWithWebRtcServer(t *testing.T) {
 			LocalIceUsernameFragments: []LocalIceUsernameFragment{},
 			TupleHashes:               []TupleHash{},
 		}.String(), webRtcServerDump.String())
+
+		worker.Close()
 	})
 
 	t.Run(`router.createWebRtcTransport() with webRtcServer succeeds and webRtcServer is closed`, func(t *testing.T) {
@@ -343,5 +346,7 @@ func TestRouterCreateWebRtcTransportWithWebRtcServer(t *testing.T) {
 			Id:           router.Id(),
 			TransportIds: []string{},
 		}.String(), routerDump.String())
+
+		worker.Close()
 	})
 }


### PR DESCRIPTION
Several tests create mediasoup workers and don't close them after finishing, which leaves leaked goroutines that are blocking PR #31.

This change provides a fix for all those tests. Mostly it just clsoes resources after using them.

The biggest change is operation of CreateRouter() in helper_test.go:

* If CreateRouter(worker) is called, it just uses it.
* If CreateRouter() is called (without worker), a temporary one was created and never closed; this change introduces the assumption that the temporary worker can be closed whenever the router is closed, so it uses `router.OnClose` to hook on the router closing and closes the worker.

This doesn't change the behavior of CreateRouter, so it is transpaent for users of this function.

Another change is that the `sctp.Association` in sctp_test.go is also saved as part of the Suite, because it needs to be explicitly closed when the test suite finishes.

sctp_test.go used wrongly named variable "stcpStream", now renamed to "sctpStream" to go with the new "sctpAssociation".