### PR TITLE
refactor: RTP stream statistics and consumer score types

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ func main() {
     // Create WebRTC transport
     transport, err := router.CreateWebRtcTransport(&mediasoup.WebRtcTransportOptions{
         ListenInfos: []mediasoup.TransportListenInfo{
-            {IP: "0.0.0.0", AnnouncedAddress: "your.public.ip"},
+            {Ip: "0.0.0.0", AnnouncedAddress: "your.public.ip"},
         },
     })
 

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -165,7 +165,7 @@ func TestConsumerDump(t *testing.T) {
 	assert.Equal(t, []*RtpEncodingParameters{
 		{Ssrc: audioProducer.ConsumableRtpParameters().Encodings[0].Ssrc, Dtx: true, ScalabilityMode: "S1T1"},
 	}, data.ConsumableRtpEncodings)
-	assert.Equal(t, []uint8{100}, data.SupportedCodecPayloadTypes)
+	assert.Equal(t, []int{100}, data.SupportedCodecPayloadTypes)
 	assert.False(t, data.Paused)
 	assert.False(t, data.ProducerPaused)
 
@@ -239,7 +239,7 @@ func TestConsumerDump(t *testing.T) {
 		{Ssrc: videoProducer.ConsumableRtpParameters().Encodings[2].Ssrc, ScalabilityMode: "L1T5"},
 		{Ssrc: videoProducer.ConsumableRtpParameters().Encodings[3].Ssrc, ScalabilityMode: "L1T5"},
 	}, data.ConsumableRtpEncodings)
-	assert.Equal(t, []byte{103}, data.SupportedCodecPayloadTypes)
+	assert.Equal(t, []int{103}, data.SupportedCodecPayloadTypes)
 	assert.True(t, data.Paused)
 	assert.True(t, data.ProducerPaused)
 }
@@ -255,22 +255,18 @@ func TestConsumerGetStats(t *testing.T) {
 	expectedConsumerStats := []*ConsumerStat{}
 	for _, stats := range consumerStats {
 		expectedConsumerStats = append(expectedConsumerStats, &ConsumerStat{
-			Type: stats.Type,
-			BaseRtpStreamStats: BaseRtpStreamStats{
-				Kind:     stats.Kind,
-				MimeType: stats.MimeType,
-				Ssrc:     stats.Ssrc,
-			},
+			Type:     stats.Type,
+			Kind:     stats.Kind,
+			MimeType: stats.MimeType,
+			Ssrc:     stats.Ssrc,
 		})
 	}
 
 	assert.Contains(t, expectedConsumerStats, &ConsumerStat{
-		Type: "outbound-rtp",
-		BaseRtpStreamStats: BaseRtpStreamStats{
-			Kind:     "audio",
-			MimeType: "audio/opus",
-			Ssrc:     audioConsumer.RtpParameters().Encodings[0].Ssrc,
-		},
+		Type:     "outbound-rtp",
+		Kind:     "audio",
+		MimeType: "audio/opus",
+		Ssrc:     audioConsumer.RtpParameters().Encodings[0].Ssrc,
 	})
 
 	videoProducer := createVideoProducer(transport)
@@ -281,22 +277,18 @@ func TestConsumerGetStats(t *testing.T) {
 	expectedConsumerStats = []*ConsumerStat{}
 	for _, stats := range consumerStats {
 		expectedConsumerStats = append(expectedConsumerStats, &ConsumerStat{
-			Type: stats.Type,
-			BaseRtpStreamStats: BaseRtpStreamStats{
-				Kind:     stats.Kind,
-				MimeType: stats.MimeType,
-				Ssrc:     stats.Ssrc,
-			},
+			Type:     stats.Type,
+			Kind:     stats.Kind,
+			MimeType: stats.MimeType,
+			Ssrc:     stats.Ssrc,
 		})
 	}
 
 	assert.Contains(t, expectedConsumerStats, &ConsumerStat{
-		Type: "outbound-rtp",
-		BaseRtpStreamStats: BaseRtpStreamStats{
-			Kind:     "video",
-			MimeType: "video/H264",
-			Ssrc:     videoConsumer.RtpParameters().Encodings[0].Ssrc,
-		},
+		Type:     "outbound-rtp",
+		Kind:     "video",
+		MimeType: "video/H264",
+		Ssrc:     videoConsumer.RtpParameters().Encodings[0].Ssrc,
 	})
 }
 

--- a/consumer_types.go
+++ b/consumer_types.go
@@ -52,15 +52,15 @@ type ConsumerOptions struct {
 
 // ConsumerScore define "score" event data
 type ConsumerScore struct {
-	// Score of the RTP stream of the c
-	Score uint8 `json:"score"`
+	// Score of the RTP stream of the consumer.
+	Score int `json:"score"`
 
 	// Score of the currently selected RTP stream of the producer.
-	ProducerScore uint8 `json:"producerScore"`
+	ProducerScore int `json:"producerScore"`
 
 	// ProducerScores is the scores of all RTP streams in the producer ordered
 	// by encoding (just useful when the producer uses simulcast).
-	ProducerScores []uint8 `json:"producerScores,omitempty"`
+	ProducerScores []int `json:"producerScores,omitempty"`
 }
 
 type ConsumerLayers struct {
@@ -96,7 +96,7 @@ type BaseConsumerDump struct {
 	Kind                       MediaKind                `json:"kind"`
 	RtpParameters              *RtpParameters           `json:"rtpParameters"`
 	ConsumableRtpEncodings     []*RtpEncodingParameters `json:"consumableRtpEncodings,omitempty"`
-	SupportedCodecPayloadTypes []uint8                  `json:"supportedCodecPayloadTypes"`
+	SupportedCodecPayloadTypes []int                    `json:"supportedCodecPayloadTypes"`
 	TraceEventTypes            []ConsumerTraceEventType `json:"traceEventTypes"`
 	Paused                     bool                     `json:"paused"`
 	ProducerPaused             bool                     `json:"producerPaused"`
@@ -164,7 +164,7 @@ type RtxStreamParameters struct {
 	Cname       string `json:"cname"`
 }
 
-type ConsumerStat = RtpStreamSendStats
+type ConsumerStat = RtpStreamStats
 
 // ConsumerTraceEventData is "trace" event data.
 type ConsumerTraceEventData struct {

--- a/data_producer.go
+++ b/data_producer.go
@@ -54,7 +54,7 @@ func (p *DataProducer) Type() DataProducerType {
 
 // SctpStreamParameters returns SCTP stream parameters.
 func (p *DataProducer) SctpStreamParameters() *SctpStreamParameters {
-	return p.data.SctpStreamParameters
+	return clone(p.data.SctpStreamParameters)
 }
 
 // Label returns DataChannel label.

--- a/producer.go
+++ b/producer.go
@@ -9,7 +9,6 @@ import (
 	FbsProducer "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/Producer"
 	FbsRequest "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/Request"
 	FbsRtpParameters "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/RtpParameters"
-	FbsRtpStream "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/RtpStream"
 	FbsTransport "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/Transport"
 
 	"github.com/jiyeyuran/mediasoup-go/v2/internal/channel"
@@ -191,27 +190,7 @@ func (p *Producer) GetStats() ([]*ProducerStat, error) {
 	}
 	resp := msg.(*FbsProducer.GetStatsResponseT)
 
-	return collect(resp.Stats, func(stat *FbsRtpStream.StatsT) *ProducerStat {
-		recvStats := stat.Data.Value.(*FbsRtpStream.RecvStatsT)
-		baseStats := recvStats.Base.Data.Value.(*FbsRtpStream.BaseStatsT)
-		bitrateByLayer := ifElse(len(recvStats.BitrateByLayer) > 0, func() map[string]uint32 {
-			return make(map[string]uint32)
-		})
-
-		for _, layer := range recvStats.BitrateByLayer {
-			bitrateByLayer[layer.Layer] = layer.Bitrate
-		}
-
-		return &ProducerStat{
-			BaseRtpStreamStats: parseBaseRtpStreamStats(baseStats),
-			Type:               "inbound-rtp",
-			Jitter:             recvStats.Jitter,
-			PacketCount:        recvStats.PacketCount,
-			ByteCount:          recvStats.ByteCount,
-			Bitrate:            recvStats.Bitrate,
-			BitrateByLayer:     bitrateByLayer,
-		}
-	}), nil
+	return collect(resp.Stats, parseRtpStreamStats), nil
 }
 
 // Pause the producer.

--- a/producer_types.go
+++ b/producer_types.go
@@ -119,4 +119,4 @@ type ProducerTraceEventData struct {
 }
 
 // ProducerStat define the statistic info of a producer
-type ProducerStat = RtpStreamRecvStats
+type ProducerStat = RtpStreamStats

--- a/router.go
+++ b/router.go
@@ -345,7 +345,7 @@ func (r *Router) CreateWebRtcTransport(options *WebRtcTransportOptions) (*Transp
 	if options.InitialAvailableOutgoingBitrate > 0 {
 		o.InitialAvailableOutgoingBitrate = options.InitialAvailableOutgoingBitrate
 	}
-	if options.NumSctpStreams != nil {
+	if options.NumSctpStreams != nil && options.NumSctpStreams.OS > 0 && options.NumSctpStreams.MIS > 0 {
 		o.NumSctpStreams = options.NumSctpStreams
 	}
 	if options.MaxSctpMessageSize > 0 {
@@ -715,7 +715,7 @@ func (r *Router) PipeToRouter(options *PipeToRouterOptions) (result *PipeToRoute
 	o := &PipeToRouterOptions{
 		ListenInfo: TransportListenInfo{
 			Protocol: TransportProtocolUDP,
-			IP:       "127.0.0.1",
+			Ip:       "127.0.0.1",
 		},
 		ProducerId:     options.ProducerId,
 		DataProducerId: options.DataProducerId,

--- a/router_test.go
+++ b/router_test.go
@@ -85,13 +85,13 @@ func TestCreateWebRtcTransport(t *testing.T) {
 	router, _ := worker.CreateRouter(&RouterOptions{})
 	transport1, err := router.CreateWebRtcTransport(&WebRtcTransportOptions{
 		ListenInfos: []TransportListenInfo{
-			{IP: "127.0.0.1"},
+			{Ip: "127.0.0.1"},
 		},
 	})
 	require.NoError(t, err)
 	webRtcServer, _ := worker.CreateWebRtcServer(&WebRtcServerOptions{
 		ListenInfos: []*TransportListenInfo{
-			{Protocol: TransportProtocolUDP, IP: "127.0.0.1", Port: 0},
+			{Protocol: TransportProtocolUDP, Ip: "127.0.0.1", Port: 0},
 		},
 	})
 	transport2, err := router.CreateWebRtcTransport(&WebRtcTransportOptions{
@@ -120,7 +120,7 @@ func TestCreateWebRtcTransportWithPortRange(t *testing.T) {
 
 	transport1, err := router.CreateWebRtcTransport(&WebRtcTransportOptions{
 		ListenInfos: []TransportListenInfo{
-			{Protocol: TransportProtocolUDP, IP: "127.0.0.1", PortRange: portRange},
+			{Protocol: TransportProtocolUDP, Ip: "127.0.0.1", PortRange: portRange},
 		},
 	})
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestCreateWebRtcTransportWithPortRange(t *testing.T) {
 
 	transport2, err := router.CreateWebRtcTransport(&WebRtcTransportOptions{
 		ListenInfos: []TransportListenInfo{
-			{Protocol: TransportProtocolUDP, IP: "127.0.0.1", PortRange: portRange},
+			{Protocol: TransportProtocolUDP, Ip: "127.0.0.1", PortRange: portRange},
 		},
 	})
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestCreateWebRtcTransportWithPortRange(t *testing.T) {
 	// No more available ports so it must fail
 	_, err = router.CreateWebRtcTransport(&WebRtcTransportOptions{
 		ListenInfos: []TransportListenInfo{
-			{Protocol: TransportProtocolUDP, IP: "127.0.0.1", PortRange: portRange},
+			{Protocol: TransportProtocolUDP, Ip: "127.0.0.1", PortRange: portRange},
 		},
 	})
 	assert.Error(t, err)
@@ -156,7 +156,7 @@ func TestCreatePlainTransport(t *testing.T) {
 	router, _ := worker.CreateRouter(&RouterOptions{})
 	transport, err := router.CreatePlainTransport(&PlainTransportOptions{
 		ListenInfo: TransportListenInfo{
-			IP: "127.0.0.1",
+			Ip: "127.0.0.1",
 		},
 	})
 	require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestCreatePipeTransport(t *testing.T) {
 	router1 := createRouter(nil)
 	transport1, _ := router1.CreateWebRtcTransport(&WebRtcTransportOptions{
 		ListenInfos: []TransportListenInfo{
-			{IP: "127.0.0.1"},
+			{Ip: "127.0.0.1"},
 		},
 		EnableSctp: true,
 	})
@@ -219,7 +219,7 @@ func TestCreatePipeTransport(t *testing.T) {
 
 	t.Run("enable rtx", func(t *testing.T) {
 		pipeTransport, err := router1.CreatePipeTransport(&PipeTransportOptions{
-			ListenInfo: TransportListenInfo{IP: "127.0.0.1"},
+			ListenInfo: TransportListenInfo{Ip: "127.0.0.1"},
 			EnableRtx:  true,
 		})
 		assert.NoError(t, err)
@@ -227,7 +227,7 @@ func TestCreatePipeTransport(t *testing.T) {
 
 		// No SRTP enabled so passing srtpParameters must fail.
 		router1.CreatePipeTransport(&PipeTransportOptions{
-			ListenInfo: TransportListenInfo{IP: "127.0.0.1"},
+			ListenInfo: TransportListenInfo{Ip: "127.0.0.1"},
 			EnableRtx:  true,
 		})
 		assert.NoError(t, err)
@@ -306,7 +306,7 @@ func TestCreatePipeTransport(t *testing.T) {
 		assert.Equal(t, ConsumerScore{
 			Score:          10,
 			ProducerScore:  10,
-			ProducerScores: []uint8{},
+			ProducerScores: []int{},
 		}, pipeConsumer.Score())
 
 		pipeTransport.Close()
@@ -314,7 +314,7 @@ func TestCreatePipeTransport(t *testing.T) {
 
 	t.Run("invalid srtpParameters must fail", func(t *testing.T) {
 		pipeTransport, _ := router1.CreatePipeTransport(&PipeTransportOptions{
-			ListenInfo: TransportListenInfo{IP: "127.0.0.1"},
+			ListenInfo: TransportListenInfo{Ip: "127.0.0.1"},
 			EnableRtx:  true,
 		})
 		err := pipeTransport.Connect(&TransportConnectOptions{
@@ -330,7 +330,7 @@ func TestCreatePipeTransport(t *testing.T) {
 
 	t.Run("enable srtp", func(t *testing.T) {
 		pipeTransport, err := router1.CreatePipeTransport(&PipeTransportOptions{
-			ListenInfo: TransportListenInfo{IP: "127.0.0.1"},
+			ListenInfo: TransportListenInfo{Ip: "127.0.0.1"},
 			EnableSrtp: true,
 		})
 		assert.NoError(t, err)
@@ -392,7 +392,7 @@ func TestCreatePipeTransport(t *testing.T) {
 	t.Run("fixed port", func(t *testing.T) {
 		port := pickUdpPort()
 		pipeTransport, _ := router1.CreatePipeTransport(&PipeTransportOptions{
-			ListenInfo: TransportListenInfo{IP: "127.0.0.1", Port: port},
+			ListenInfo: TransportListenInfo{Ip: "127.0.0.1", Port: port},
 		})
 
 		assert.Equal(t, port, pipeTransport.Data().PipeTransportData.Tuple.LocalPort)
@@ -440,13 +440,13 @@ func TestPipeToRouter(t *testing.T) {
 
 	transport1, _ := router1.CreateWebRtcTransport(&WebRtcTransportOptions{
 		ListenInfos: []TransportListenInfo{
-			{IP: "127.0.0.1"},
+			{Ip: "127.0.0.1"},
 		},
 		EnableSctp: true,
 	})
 	transport2, _ := router2.CreateWebRtcTransport(&WebRtcTransportOptions{
 		ListenInfos: []TransportListenInfo{
-			{IP: "127.0.0.1"},
+			{Ip: "127.0.0.1"},
 		},
 		EnableSctp: true,
 	})
@@ -618,7 +618,7 @@ func TestPipeToRouter(t *testing.T) {
 		assert.Equal(t, ConsumerScore{
 			Score:          10,
 			ProducerScore:  10,
-			ProducerScores: []uint8{},
+			ProducerScores: []int{},
 		}, pipeConsumer.Score())
 
 		assert.Equal(t, audioProducer.Id(), pipeProducer.Id())
@@ -721,7 +721,7 @@ func TestPipeToRouter(t *testing.T) {
 		assert.Equal(t, ConsumerScore{
 			Score:          10,
 			ProducerScore:  10,
-			ProducerScores: []uint8{},
+			ProducerScores: []int{},
 		}, pipeConsumer.Score())
 
 		assert.Equal(t, videoProducer.Id(), pipeProducer.Id())
@@ -835,7 +835,7 @@ func TestPipeToRouter(t *testing.T) {
 		assert.Equal(t, ConsumerScore{
 			Score:          10,
 			ProducerScore:  0,
-			ProducerScores: []uint8{0, 0, 0},
+			ProducerScores: []int{0, 0, 0},
 		}, videoConsumer.Score())
 	})
 

--- a/rtp_observer.go
+++ b/rtp_observer.go
@@ -197,7 +197,7 @@ func (r *RtpObserver) handleWorkerNotifications() {
 
 			for _, handler := range handlers {
 				handler(AudioLevelObserverDominantSpeaker{
-					ProducerId: notification.ProducerId,
+					Producer: producer,
 				})
 			}
 
@@ -216,8 +216,8 @@ func (r *RtpObserver) handleWorkerNotifications() {
 					continue
 				}
 				volumes = append(volumes, AudioLevelObserverVolume{
-					ProducerId: volume.ProducerId,
-					Volume:     volume.Volume,
+					Producer: producer,
+					Volume:   volume.Volume,
 				})
 			}
 			for _, handler := range handlers {

--- a/rtp_observer_test.go
+++ b/rtp_observer_test.go
@@ -94,8 +94,8 @@ func TestRtpObserverNotification(t *testing.T) {
 	router := createRouter(nil)
 	producer := createAudioProducer(createWebRtcTransport(router))
 
-	speaker := AudioLevelObserverDominantSpeaker{ProducerId: producer.Id()}
-	volumes := []AudioLevelObserverVolume{{ProducerId: producer.Id(), Volume: -10}}
+	speaker := AudioLevelObserverDominantSpeaker{Producer: producer}
+	volumes := []AudioLevelObserverVolume{{Producer: producer, Volume: -10}}
 
 	mock.On("OnDominantSpeaker", speaker)
 	mock.On("OnSilence")
@@ -112,7 +112,7 @@ func TestRtpObserverNotification(t *testing.T) {
 		Body: &FbsNotification.BodyT{
 			Type: FbsNotification.BodyActiveSpeakerObserver_DominantSpeakerNotification,
 			Value: &FbsActiveSpeakerObserver.DominantSpeakerNotificationT{
-				ProducerId: speaker.ProducerId,
+				ProducerId: speaker.Producer.Id(),
 			},
 		},
 	})
@@ -127,7 +127,7 @@ func TestRtpObserverNotification(t *testing.T) {
 			Type: FbsNotification.BodyAudioLevelObserver_VolumesNotification,
 			Value: &FbsAudioLevelObserver.VolumesNotificationT{
 				Volumes: []*FbsAudioLevelObserver.VolumeT{
-					{ProducerId: volumes[0].ProducerId, Volume: volumes[0].Volume},
+					{ProducerId: volumes[0].Producer.Id(), Volume: volumes[0].Volume},
 				},
 			},
 		},

--- a/rtp_observer_types.go
+++ b/rtp_observer_types.go
@@ -29,14 +29,14 @@ type AudioLevelObserverOption func(*AudioLevelObserverOptions)
 
 type AudioLevelObserverDominantSpeaker struct {
 	// ProducerId is the dominant audio producer instance.
-	ProducerId string `json:"producerId"`
+	Producer *Producer
 }
 
 type AudioLevelObserverVolume struct {
 	// ProducerId is the audio producer instance.
-	ProducerId string `json:"producerId"`
+	Producer *Producer
 
 	// Volume is the average volume (in dBvo from -127 to 0) of the audio producer in the
 	// last interval.
-	Volume int8 `json:"volume"`
+	Volume int8
 }

--- a/rtp_parameters_fbs_utils.go
+++ b/rtp_parameters_fbs_utils.go
@@ -5,7 +5,6 @@ import (
 	"math"
 
 	FbsRtpParameters "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/RtpParameters"
-	FbsRtpStream "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/RtpStream"
 )
 
 func parseRtpParameters(rtpParameters *FbsRtpParameters.RtpParametersT) *RtpParameters {
@@ -246,28 +245,5 @@ func parseRtcpParameters(rtcp *FbsRtpParameters.RtcpParametersT) *RtcpParameters
 	return &RtcpParameters{
 		Cname:       rtcp.Cname,
 		ReducedSize: &rtcp.ReducedSize,
-	}
-}
-
-func parseBaseRtpStreamStats(stats *FbsRtpStream.BaseStatsT) BaseRtpStreamStats {
-	return BaseRtpStreamStats{
-		Timestamp:            stats.Timestamp,
-		Ssrc:                 stats.Ssrc,
-		Kind:                 orElse(stats.Kind == FbsRtpParameters.MediaKindVIDEO, MediaKindVideo, MediaKindAudio),
-		MimeType:             stats.MimeType,
-		PacketsLost:          stats.PacketsLost,
-		FractionLost:         stats.FractionLost,
-		PacketsDiscarded:     stats.PacketsDiscarded,
-		PacketsRetransmitted: stats.PacketsRetransmitted,
-		PacketsRepaired:      stats.PacketsRepaired,
-		NackCount:            stats.NackCount,
-		NackPacketCount:      stats.NackPacketCount,
-		PliCount:             stats.PliCount,
-		FirCount:             stats.FirCount,
-		Score:                stats.Score,
-		Rid:                  stats.Rid,
-		RtxSsrc:              stats.RtxSsrc,
-		RoundTripTime:        stats.RoundTripTime,
-		RtxPacketsDiscarded:  stats.RtxPacketsDiscarded,
 	}
 }

--- a/rtp_stream_stats_fbs_utils.go
+++ b/rtp_stream_stats_fbs_utils.go
@@ -1,0 +1,80 @@
+package mediasoup
+
+import (
+	FbsRtpParameters "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/RtpParameters"
+	FbsRtpStream "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/RtpStream"
+)
+
+func parseRtpStreamStats(stats *FbsRtpStream.StatsT) *RtpStreamStats {
+	switch stats.Data.Type {
+	case FbsRtpStream.StatsDataRecvStats:
+		return parseRtpStreamRecvStats(stats.Data.Value.(*FbsRtpStream.RecvStatsT))
+
+	case FbsRtpStream.StatsDataSendStats:
+		return parseSendStreamStats(stats.Data.Value.(*FbsRtpStream.SendStatsT))
+
+	case FbsRtpStream.StatsDataBaseStats:
+		return parseBaseStreamStats(stats.Data.Value.(*FbsRtpStream.BaseStatsT))
+
+	default:
+		return nil
+	}
+}
+
+func parseRtpStreamRecvStats(recvStats *FbsRtpStream.RecvStatsT) *RtpStreamStats {
+	stats := parseBaseStreamStats(recvStats.Base.Data.Value.(*FbsRtpStream.BaseStatsT))
+	stats.Type = "inbound-rtp"
+	stats.Jitter = recvStats.Jitter
+	stats.PacketCount = recvStats.PacketCount
+	stats.ByteCount = recvStats.ByteCount
+	stats.Bitrate = recvStats.Bitrate
+	stats.BitrateByLayer = parseBitrateByLayer(recvStats)
+
+	return stats
+}
+
+func parseSendStreamStats(sendStats *FbsRtpStream.SendStatsT) *RtpStreamStats {
+	stats := parseBaseStreamStats(sendStats.Base.Data.Value.(*FbsRtpStream.BaseStatsT))
+	stats.Type = "outbound-rtp"
+	stats.PacketCount = sendStats.PacketCount
+	stats.ByteCount = sendStats.ByteCount
+	stats.Bitrate = sendStats.Bitrate
+
+	return stats
+}
+
+func parseBaseStreamStats(stats *FbsRtpStream.BaseStatsT) *RtpStreamStats {
+	return &RtpStreamStats{
+		Timestamp:            stats.Timestamp,
+		Ssrc:                 stats.Ssrc,
+		Kind:                 orElse(stats.Kind == FbsRtpParameters.MediaKindVIDEO, MediaKindVideo, MediaKindAudio),
+		MimeType:             stats.MimeType,
+		PacketsLost:          stats.PacketsLost,
+		FractionLost:         stats.FractionLost,
+		PacketsDiscarded:     stats.PacketsDiscarded,
+		PacketsRetransmitted: stats.PacketsRetransmitted,
+		PacketsRepaired:      stats.PacketsRepaired,
+		NackCount:            stats.NackCount,
+		NackPacketCount:      stats.NackPacketCount,
+		PliCount:             stats.PliCount,
+		FirCount:             stats.FirCount,
+		Score:                stats.Score,
+		Rid:                  stats.Rid,
+		RtxSsrc:              stats.RtxSsrc,
+		RoundTripTime:        stats.RoundTripTime,
+		RtxPacketsDiscarded:  stats.RtxPacketsDiscarded,
+	}
+}
+
+func parseBitrateByLayer(stats *FbsRtpStream.RecvStatsT) map[string]uint32 {
+	if stats == nil {
+		return nil
+	}
+	bitrateByLayer := make(map[string]uint32)
+
+	for _, layer := range stats.BitrateByLayer {
+		bitrateByLayer[layer.Layer] = layer.Bitrate
+	}
+
+	return bitrateByLayer
+}

--- a/rtp_stream_stats_types.go
+++ b/rtp_stream_stats_types.go
@@ -1,24 +1,7 @@
 package mediasoup
 
-type RtpStreamRecvStats struct {
-	BaseRtpStreamStats
-	Type           string            `json:"type"`
-	Jitter         uint32            `json:"jitter"`
-	PacketCount    uint64            `json:"packetCount"`
-	ByteCount      uint64            `json:"byteCount"`
-	Bitrate        uint32            `json:"bitrate"`
-	BitrateByLayer map[string]uint32 `json:"bitrateByLayer,omitempty"`
-}
-
-type RtpStreamSendStats struct {
-	BaseRtpStreamStats
-	Type        string `json:"type"`
-	PacketCount uint64 `json:"packetCount"`
-	ByteCount   uint64 `json:"byteCount"`
-	Bitrate     uint32 `json:"bitrate"`
-}
-
-type BaseRtpStreamStats struct {
+type RtpStreamStats struct {
+	Type                 string    `json:"type"`
 	Timestamp            uint64    `json:"timestamp"`
 	Ssrc                 uint32    `json:"ssrc"`
 	Kind                 MediaKind `json:"kind"`
@@ -37,4 +20,11 @@ type BaseRtpStreamStats struct {
 	RtxSsrc              *uint32   `json:"rtxSsrc,omitempty"`
 	RoundTripTime        float32   `json:"roundTripTime,omitempty"`
 	RtxPacketsDiscarded  uint64    `json:"rtxPacketsDiscarded,omitempty"`
+	PacketCount          uint64    `json:"packetCount"`
+	ByteCount            uint64    `json:"byteCount"`
+	Bitrate              uint32    `json:"bitrate"`
+
+	// specific stats of our recv stream.
+	Jitter         uint32            `json:"jitter,omitempty"`
+	BitrateByLayer map[string]uint32 `json:"bitrateByLayer,omitempty"`
 }

--- a/sctp_test.go
+++ b/sctp_test.go
@@ -18,7 +18,7 @@ func TestSctpMessage(t *testing.T) {
 	transport, err := router.CreatePlainTransport(&PlainTransportOptions{
 		ListenInfo: TransportListenInfo{
 			Protocol:         TransportProtocolUDP,
-			IP:               "0.0.0.0",
+			Ip:               "0.0.0.0",
 			AnnouncedAddress: "127.0.0.1",
 		},
 		Comedia:    true,

--- a/transport_fbs_utils.go
+++ b/transport_fbs_utils.go
@@ -18,7 +18,7 @@ func parseTransportTuple(tuple *FbsTransport.TupleT) *TransportTuple {
 	return &TransportTuple{
 		LocalAddress: tuple.LocalAddress,
 		LocalPort:    tuple.LocalPort,
-		Protocol:     TransportProtocol(tuple.Protocol),
+		Protocol:     TransportProtocol(strings.ToLower(tuple.Protocol.String())),
 		RemoteIp:     tuple.RemoteIp,
 		RemotePort:   tuple.RemotePort,
 	}
@@ -85,7 +85,7 @@ func convertRtpEncodingParameters(encoding *RtpEncodingParameters) *FbsRtpParame
 func convertTransportListenInfo(info TransportListenInfo) *FbsTransport.ListenInfoT {
 	return &FbsTransport.ListenInfoT{
 		Protocol:         orElse(info.Protocol == TransportProtocolTCP, FbsTransport.ProtocolTCP, FbsTransport.ProtocolUDP),
-		Ip:               info.IP,
+		Ip:               info.Ip,
 		AnnouncedAddress: info.AnnouncedAddress,
 		Port:             info.Port,
 		PortRange: &FbsTransport.PortRangeT{
@@ -121,7 +121,8 @@ func convertDtlsFingerprint(item DtlsFingerprint) *FbsWebRtcTransport.Fingerprin
 		algorithm = FbsWebRtcTransport.FingerprintAlgorithmSHA512
 
 	default:
-		algorithm = FbsWebRtcTransport.EnumValuesFingerprintAlgorithm[strings.ToUpper(item.Algorithm)]
+		key := strings.ToUpper(strings.Join(strings.Split(item.Algorithm, "-"), ""))
+		algorithm = FbsWebRtcTransport.EnumValuesFingerprintAlgorithm[key]
 	}
 
 	// avoid mediasoup crash
@@ -145,6 +146,9 @@ func parseDtlsFingerprint(item *FbsWebRtcTransport.FingerprintT) DtlsFingerprint
 	case FbsWebRtcTransport.FingerprintAlgorithmSHA224:
 		algorithm = "sha-224"
 
+	case FbsWebRtcTransport.FingerprintAlgorithmSHA256:
+		algorithm = "sha-256"
+
 	case FbsWebRtcTransport.FingerprintAlgorithmSHA384:
 		algorithm = "sha-384"
 
@@ -152,7 +156,7 @@ func parseDtlsFingerprint(item *FbsWebRtcTransport.FingerprintT) DtlsFingerprint
 		algorithm = "sha-512"
 
 	default:
-		algorithm = strings.ToLower(item.Algorithm.String())
+		algorithm = "sha-" + strings.TrimPrefix(item.Algorithm.String(), "SHA")
 	}
 
 	return DtlsFingerprint{

--- a/transport_test.go
+++ b/transport_test.go
@@ -15,7 +15,7 @@ func createWebRtcTransport(router *Router, options ...func(o *WebRtcTransportOpt
 	}
 	o := &WebRtcTransportOptions{
 		ListenInfos: []TransportListenInfo{
-			{IP: "127.0.0.1", AnnouncedAddress: "9.9.9.1", Port: 0},
+			{Ip: "127.0.0.1", AnnouncedAddress: "9.9.9.1", Port: 0},
 		},
 	}
 	for _, option := range options {
@@ -34,7 +34,7 @@ func createPlainTransport(router *Router, options ...func(o *PlainTransportOptio
 	}
 	o := &PlainTransportOptions{
 		ListenInfo: TransportListenInfo{
-			IP:               "127.0.0.1",
+			Ip:               "127.0.0.1",
 			AnnouncedAddress: "4.4.4.4",
 		},
 	}
@@ -105,7 +105,7 @@ func TestTransportGetStats(t *testing.T) {
 	transport := createWebRtcTransport(nil)
 	stats, err := transport.GetStats()
 	assert.NoError(t, err)
-	baseStats := stats.BaseTransportStats
+	baseStats := stats.BaseTransportStat
 	assert.Equal(t, "webrtc-transport", baseStats.Type)
 	assert.NotZero(t, baseStats.Timestamp)
 	baseStats.Type = ""
@@ -113,7 +113,7 @@ func TestTransportGetStats(t *testing.T) {
 	baseStats.TransportId = ""
 	assert.Empty(t, baseStats)
 
-	webrtcStats := stats.WebRtcTransportStats
+	webrtcStats := stats.WebRtcTransportStat
 	assert.EqualValues(t, "controlled", webrtcStats.IceRole)
 	assert.EqualValues(t, "new", webrtcStats.IceState)
 	assert.EqualValues(t, "new", webrtcStats.DtlsState)
@@ -123,8 +123,8 @@ func TestTransportGetStats(t *testing.T) {
 	stats, _ = transport.GetStats()
 	assert.Equal(t, "plain-transport", stats.Type)
 	assert.NotZero(t, stats.Timestamp)
-	assert.Equal(t, "4.4.4.4", stats.PlainTransportStats.Tuple.LocalAddress)
-	assert.NotZero(t, stats.PlainTransportStats.Tuple.LocalPort)
+	assert.Equal(t, "4.4.4.4", stats.PlainTransportStat.Tuple.LocalAddress)
+	assert.NotZero(t, stats.PlainTransportStat.Tuple.LocalPort)
 
 	transport = createDirectTransport(nil)
 	stats, _ = transport.GetStats()
@@ -471,7 +471,7 @@ func TestTransportConsume(t *testing.T) {
 	assert.Equal(t, ConsumerSimple, aconsumer.Type())
 	assert.False(t, aconsumer.Paused())
 	assert.False(t, aconsumer.ProducerPaused())
-	assert.Equal(t, ConsumerScore{Score: 10, ProducerScore: 0, ProducerScores: []uint8{0}}, aconsumer.Score())
+	assert.Equal(t, ConsumerScore{Score: 10, ProducerScore: 0, ProducerScores: []int{0}}, aconsumer.Score())
 	assert.Nil(t, aconsumer.CurrentLayers())
 	assert.Nil(t, aconsumer.PreferredLayers())
 	assert.Equal(t, H{"baz": "LOL"}, aconsumer.AppData())
@@ -518,7 +518,7 @@ func TestTransportConsume(t *testing.T) {
 	assert.True(t, vconsumer.Paused())
 	assert.True(t, vconsumer.ProducerPaused())
 	assert.EqualValues(t, 1, vconsumer.Priority())
-	assert.Equal(t, ConsumerScore{Score: 10, ProducerScore: 0, ProducerScores: []uint8{0, 0, 0, 0}}, vconsumer.Score())
+	assert.Equal(t, ConsumerScore{Score: 10, ProducerScore: 0, ProducerScores: []int{0, 0, 0, 0}}, vconsumer.Score())
 	assert.Nil(t, vconsumer.CurrentLayers())
 	assert.Equal(t, H{"baz": "LOL"}, vconsumer.AppData())
 
@@ -559,7 +559,7 @@ func TestTransportConsume(t *testing.T) {
 	assert.False(t, pipeConsumer.Paused())
 	assert.True(t, pipeConsumer.ProducerPaused())
 	assert.EqualValues(t, 1, pipeConsumer.Priority())
-	assert.Equal(t, ConsumerScore{Score: 10, ProducerScore: 10, ProducerScores: []uint8{0, 0, 0, 0}}, pipeConsumer.Score())
+	assert.Equal(t, ConsumerScore{Score: 10, ProducerScore: 10, ProducerScores: []int{0, 0, 0, 0}}, pipeConsumer.Score())
 	assert.Nil(t, pipeConsumer.PreferredLayers())
 	assert.Nil(t, pipeConsumer.CurrentLayers())
 

--- a/transport_types.go
+++ b/transport_types.go
@@ -54,7 +54,7 @@ type PlainTransportOptions struct {
 	// RtcpMux define wether use RTCP-mux (RTP and RTCP in the same port). Default true.
 	RtcpMux *bool `json:"rtcpMux,omitempty"`
 
-	// Comedia define whether remote IP:port should be auto-detected based on first RTP/RTCP
+	// Comedia define whether remote ip:port should be auto-detected based on first RTP/RTCP
 	// packet received. If enabled, connect() method must not be called unless
 	// SRTP is enabled. If so, it must be called with just remote SRTP parameters.
 	// Default false.
@@ -152,8 +152,8 @@ type TransportListenInfo struct {
 	// Protocol network protocol
 	Protocol TransportProtocol `json:"protocol"`
 
-	// IP listening IPv4 or IPv6
-	IP string `json:"ip"`
+	// Ip listening IPv4 or IPv6
+	Ip string `json:"ip"`
 
 	// AnnouncedAddress announced IPv4, IPv6 or hostname (useful when running mediasoup behind NAT with private IP)
 	AnnouncedAddress string `json:"announcedAddress,omitempty"`
@@ -314,15 +314,15 @@ type SctpListener struct {
 	StreamIdTable []KeyValue[uint16, string] `json:"streamIdTable,omitempty"`
 }
 
-type TransportStats struct {
-	BaseTransportStats
-	*WebRtcTransportStats
-	*PlainTransportStats
-	*PipeTransportStats
+type TransportStat struct {
+	BaseTransportStat
+	*WebRtcTransportStat
+	*PlainTransportStat
+	*PipeTransportStat
 }
 
-// BaseTransportStats represents base transport statistics.
-type BaseTransportStats struct {
+// BaseTransportStat represents base transport statistics.
+type BaseTransportStat struct {
 	Type                     string    `json:"type"`
 	TransportId              string    `json:"transportId"`
 	Timestamp                uint64    `json:"timestamp"`
@@ -350,21 +350,21 @@ type BaseTransportStats struct {
 	RtpPacketLossSent        *float64  `json:"rtpPacketLossSent,omitempty"`
 }
 
-type WebRtcTransportStats struct {
+type WebRtcTransportStat struct {
 	IceRole          string          `json:"iceRole"`
 	IceState         IceState        `json:"iceState"`
 	DtlsState        DtlsState       `json:"dtlsState"`
 	IceSelectedTuple *TransportTuple `json:"iceSelectedTuple,omitempty"`
 }
 
-type PlainTransportStats struct {
+type PlainTransportStat struct {
 	RtcpMux   bool            `json:"rtcp_mux"`
 	Comedia   bool            `json:"comedia"`
 	Tuple     TransportTuple  `json:"tuple"`
 	RtcpTuple *TransportTuple `json:"rtcpTuple,omitempty"`
 }
 
-type PipeTransportStats struct {
+type PipeTransportStat struct {
 	Tuple TransportTuple `json:"tuple"`
 }
 

--- a/types.go
+++ b/types.go
@@ -1,6 +1,6 @@
 package mediasoup
 
-type H map[string]any
+type H = map[string]any
 
 // KeyValue represents a key-value pair.
 type KeyValue[K any, V any] struct {

--- a/webrtc_server.go
+++ b/webrtc_server.go
@@ -12,7 +12,7 @@ import (
 
 // WebRtcServer brings the ability to listen on a single UDP/TCP port to WebRtcTransports.
 // Instead of passing listenIps to router.CreateWebRtcTransport() pass webRtcServer with an
-// instance of a WebRtcServer so the new WebRTC transport will not listen on its own IP:port(s)
+// instance of a WebRtcServer so the new WebRTC transport will not listen on its own Ip:port(s)
 // but will have its network traffic handled by the WebRTC server instead.
 //
 // A WebRTC server exists within the context of a Worker, meaning that if your app launches N

--- a/webrtc_server_test.go
+++ b/webrtc_server_test.go
@@ -11,7 +11,7 @@ func TestWebRtcServerClose(t *testing.T) {
 	worker := newTestWorker()
 	server, _ := worker.CreateWebRtcServer(&WebRtcServerOptions{
 		ListenInfos: []*TransportListenInfo{
-			{Protocol: TransportProtocolUDP, IP: "127.0.0.1", Port: pickUdpPort()},
+			{Protocol: TransportProtocolUDP, Ip: "127.0.0.1", Port: pickUdpPort()},
 		},
 	})
 	err := server.Close()
@@ -24,7 +24,7 @@ func TestWebRtcServerDump(t *testing.T) {
 	worker := newTestWorker()
 	server, _ := worker.CreateWebRtcServer(&WebRtcServerOptions{
 		ListenInfos: []*TransportListenInfo{
-			{Protocol: TransportProtocolUDP, IP: "127.0.0.1", Port: pickTcpPort()},
+			{Protocol: TransportProtocolUDP, Ip: "127.0.0.1", Port: pickTcpPort()},
 		},
 	})
 	dump, err := server.Dump()

--- a/worker.go
+++ b/worker.go
@@ -394,7 +394,7 @@ func (w *Worker) CreateWebRtcServer(options *WebRtcServerOptions) (*WebRtcServer
 	for i, info := range options.ListenInfos {
 		req.ListenInfos[i] = &FbsTransport.ListenInfoT{
 			Protocol:         orElse(info.Protocol == TransportProtocolTCP, FbsTransport.ProtocolTCP, FbsTransport.ProtocolUDP),
-			Ip:               info.IP,
+			Ip:               info.Ip,
 			Port:             info.Port,
 			AnnouncedAddress: info.AnnouncedAddress,
 			SendBufferSize:   info.SendBufferSize,

--- a/worker_test.go
+++ b/worker_test.go
@@ -97,8 +97,8 @@ func TestWorkerCreateWebRtcServer(t *testing.T) {
 	worker := newTestWorker()
 	server, err := worker.CreateWebRtcServer(&WebRtcServerOptions{
 		ListenInfos: []*TransportListenInfo{
-			{Protocol: TransportProtocolUDP, IP: "127.0.0.1", Port: pickUdpPort()},
-			{Protocol: TransportProtocolTCP, IP: "127.0.0.1", AnnouncedAddress: "foo.bar.org", Port: pickTcpPort()},
+			{Protocol: TransportProtocolUDP, Ip: "127.0.0.1", Port: pickUdpPort()},
+			{Protocol: TransportProtocolTCP, Ip: "127.0.0.1", AnnouncedAddress: "foo.bar.org", Port: pickTcpPort()},
 		},
 	})
 	require.NoError(t, err)
@@ -162,8 +162,8 @@ func TestWorkerNoGoroutineLeaks(t *testing.T) {
 
 	server, _ := worker.CreateWebRtcServer(&WebRtcServerOptions{
 		ListenInfos: []*TransportListenInfo{
-			{Protocol: TransportProtocolUDP, IP: "127.0.0.1", Port: 0},
-			{Protocol: TransportProtocolTCP, IP: "127.0.0.1", AnnouncedAddress: "foo.bar.org", Port: 0},
+			{Protocol: TransportProtocolUDP, Ip: "127.0.0.1", Port: 0},
+			{Protocol: TransportProtocolTCP, Ip: "127.0.0.1", AnnouncedAddress: "foo.bar.org", Port: 0},
 		},
 	})
 


### PR DESCRIPTION
- Changed ConsumerScore and ProducerScore types from uint8 to int for consistency.
- Updated ProducerScores slice type from []uint8 to []int for avoiding json marshal []uint8 to base64 string.
- Refactored ProducerStat and ConsumerStat types to use RtpStreamStats instead of RtpStreamRecvStats and RtpStreamSendStats.
- Introduced new utility functions for parsing RTP stream statistics.
- Updated SCTP stream parameters handling in DataProducer to return a clone instead of a reference.
- Adjusted Router and Transport types to use consistent field names (IP to Ip).
- Modified tests to reflect changes in types and structures, ensuring compatibility with new definitions.