### PR TITLE
Improve UUID generation with prefixes and consistency

### DIFF
--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	RequestTimeout = time.Second * 5
-	MaxMessageLen  = 4194308
-	MaxRequestId   = 4294967295
+	DefaultHandlerID = "worker"
+	RequestTimeout   = time.Second * 5
+	MaxMessageLen    = 4194308
+	MaxRequestId     = 4294967295
 )
 
 type Channel struct {
@@ -127,7 +128,7 @@ func (c *Channel) Request(ctx context.Context, req *FbsRequest.RequestT) (any, e
 
 	req.Id = c.nextId
 	if len(req.HandlerId) == 0 {
-		req.HandlerId = "default"
+		req.HandlerId = DefaultHandlerID
 	}
 	if req.Body == nil {
 		req.Body = &FbsRequest.BodyT{

--- a/router.go
+++ b/router.go
@@ -265,7 +265,7 @@ func (r *Router) CreateActiveSpeakerObserverContext(ctx context.Context, options
 		option(o)
 	}
 
-	rtpObserverId := uuid(rtpObserverPrefix)
+	rtpObserverId := UUID(rtpObserverPrefix)
 
 	_, err := r.channel.Request(ctx, &FbsRequest.RequestT{
 		Method:    FbsRequest.MethodROUTER_CREATE_ACTIVESPEAKEROBSERVER,
@@ -310,7 +310,7 @@ func (r *Router) CreateAudioLevelObserverContext(ctx context.Context, options ..
 		option(o)
 	}
 
-	rtpObserverId := uuid(rtpObserverPrefix)
+	rtpObserverId := UUID(rtpObserverPrefix)
 
 	_, err := r.channel.Request(ctx, &FbsRequest.RequestT{
 		Method:    FbsRequest.MethodROUTER_CREATE_AUDIOLEVELOBSERVER,
@@ -384,7 +384,7 @@ func (r *Router) CreateWebRtcTransportContext(ctx context.Context, options *WebR
 		o.AppData = options.AppData
 	}
 
-	transportId := uuid(transportPrefix)
+	transportId := UUID(transportPrefix)
 	baseTranportOptions := &FbsTransport.OptionsT{
 		InitialAvailableOutgoingBitrate: ref(o.InitialAvailableOutgoingBitrate),
 		EnableSctp:                      o.EnableSctp,
@@ -546,7 +546,7 @@ func (r *Router) CreatePlainTransportContext(ctx context.Context, options *Plain
 		o.AppData = options.AppData
 	}
 
-	transportId := uuid(transportPrefix)
+	transportId := UUID(transportPrefix)
 	baseTranportOptions := &FbsTransport.OptionsT{
 		EnableSctp: o.EnableSctp,
 		NumSctpStreams: &FbsSctpParameters.NumSctpStreamsT{
@@ -646,7 +646,7 @@ func (r *Router) CreatePipeTransportContext(ctx context.Context, options *PipeTr
 		o.AppData = options.AppData
 	}
 
-	transportId := uuid(transportPrefix)
+	transportId := UUID(transportPrefix)
 	baseTranportOptions := &FbsTransport.OptionsT{
 		EnableSctp: o.EnableSctp,
 		NumSctpStreams: &FbsSctpParameters.NumSctpStreamsT{
@@ -726,7 +726,7 @@ func (r *Router) CreateDirectTransportContext(ctx context.Context, options *Dire
 		}
 	}
 
-	transportId := uuid(transportPrefix)
+	transportId := UUID(transportPrefix)
 	baseTranportOptions := &FbsTransport.OptionsT{
 		Direct:         true,
 		MaxMessageSize: &o.MaxMessageSize,

--- a/router.go
+++ b/router.go
@@ -265,7 +265,7 @@ func (r *Router) CreateActiveSpeakerObserverContext(ctx context.Context, options
 		option(o)
 	}
 
-	rtpObserverId := uuid()
+	rtpObserverId := uuid(rtpObserverPrefix)
 
 	_, err := r.channel.Request(ctx, &FbsRequest.RequestT{
 		Method:    FbsRequest.MethodROUTER_CREATE_ACTIVESPEAKEROBSERVER,
@@ -310,7 +310,7 @@ func (r *Router) CreateAudioLevelObserverContext(ctx context.Context, options ..
 		option(o)
 	}
 
-	rtpObserverId := uuid()
+	rtpObserverId := uuid(rtpObserverPrefix)
 
 	_, err := r.channel.Request(ctx, &FbsRequest.RequestT{
 		Method:    FbsRequest.MethodROUTER_CREATE_AUDIOLEVELOBSERVER,
@@ -384,7 +384,7 @@ func (r *Router) CreateWebRtcTransportContext(ctx context.Context, options *WebR
 		o.AppData = options.AppData
 	}
 
-	transportId := uuid()
+	transportId := uuid(transportPrefix)
 	baseTranportOptions := &FbsTransport.OptionsT{
 		InitialAvailableOutgoingBitrate: ref(o.InitialAvailableOutgoingBitrate),
 		EnableSctp:                      o.EnableSctp,
@@ -546,7 +546,7 @@ func (r *Router) CreatePlainTransportContext(ctx context.Context, options *Plain
 		o.AppData = options.AppData
 	}
 
-	transportId := uuid()
+	transportId := uuid(transportPrefix)
 	baseTranportOptions := &FbsTransport.OptionsT{
 		EnableSctp: o.EnableSctp,
 		NumSctpStreams: &FbsSctpParameters.NumSctpStreamsT{
@@ -646,7 +646,7 @@ func (r *Router) CreatePipeTransportContext(ctx context.Context, options *PipeTr
 		o.AppData = options.AppData
 	}
 
-	transportId := uuid()
+	transportId := uuid(transportPrefix)
 	baseTranportOptions := &FbsTransport.OptionsT{
 		EnableSctp: o.EnableSctp,
 		NumSctpStreams: &FbsSctpParameters.NumSctpStreamsT{
@@ -726,7 +726,7 @@ func (r *Router) CreateDirectTransportContext(ctx context.Context, options *Dire
 		}
 	}
 
-	transportId := uuid()
+	transportId := uuid(transportPrefix)
 	baseTranportOptions := &FbsTransport.OptionsT{
 		Direct:         true,
 		MaxMessageSize: &o.MaxMessageSize,

--- a/transport.go
+++ b/transport.go
@@ -640,7 +640,7 @@ func (t *Transport) ProduceContext(ctx context.Context, options *ProducerOptions
 			return nil, fmt.Errorf(`a Producer with same id "%s" already exists`, id)
 		}
 	} else {
-		id = uuid()
+		id = uuid(transportPrefix)
 	}
 	if rtpParameters == nil {
 		rtpParameters = &RtpParameters{}
@@ -668,7 +668,7 @@ func (t *Transport) ProduceContext(ctx context.Context, options *ProducerOptions
 			} else {
 				// Otherwise if we don't have yet a CNAME for Producers and the RTP parameters
 				// do not include CNAME, create a random one.
-				t.cname = uuid()[:8]
+				t.cname = randString(8)
 			}
 		})
 		// Override Producer's CNAME.
@@ -846,7 +846,7 @@ func (t *Transport) ConsumeContext(ctx context.Context, options *ConsumerOptions
 		}
 	}
 
-	consumerId := uuid()
+	consumerId := uuid(consumerPrefix)
 	typ := orElse(options.Pipe || t.Type() == TransportPipe, ConsumerPipe, ConsumerType(producer.Type()))
 
 	msg, err := t.channel.Request(ctx, &FbsRequest.RequestT{
@@ -1005,7 +1005,7 @@ func (t *Transport) ProduceDataContext(ctx context.Context, options *DataProduce
 			return nil, fmt.Errorf(`a DataProducer with same id "%s" already exists`, id)
 		}
 	} else {
-		id = uuid()
+		id = uuid(dataProducerPrefix)
 	}
 
 	sctpStreamParameters := clone(options.SctpStreamParameters)
@@ -1121,7 +1121,7 @@ func (t *Transport) ConsumeDataContext(ctx context.Context, options *DataConsume
 		}
 	}
 
-	dataConsumerId := uuid()
+	dataConsumerId := uuid(dataConsumerPrefix)
 
 	_, err = t.channel.Request(ctx, &FbsRequest.RequestT{
 		Method:    FbsRequest.MethodTRANSPORT_CONSUME_DATA,

--- a/transport.go
+++ b/transport.go
@@ -640,7 +640,7 @@ func (t *Transport) ProduceContext(ctx context.Context, options *ProducerOptions
 			return nil, fmt.Errorf(`a Producer with same id "%s" already exists`, id)
 		}
 	} else {
-		id = uuid(transportPrefix)
+		id = UUID(transportPrefix)
 	}
 	if rtpParameters == nil {
 		rtpParameters = &RtpParameters{}
@@ -846,7 +846,7 @@ func (t *Transport) ConsumeContext(ctx context.Context, options *ConsumerOptions
 		}
 	}
 
-	consumerId := uuid(consumerPrefix)
+	consumerId := UUID(consumerPrefix)
 	typ := orElse(options.Pipe || t.Type() == TransportPipe, ConsumerPipe, ConsumerType(producer.Type()))
 
 	msg, err := t.channel.Request(ctx, &FbsRequest.RequestT{
@@ -1005,7 +1005,7 @@ func (t *Transport) ProduceDataContext(ctx context.Context, options *DataProduce
 			return nil, fmt.Errorf(`a DataProducer with same id "%s" already exists`, id)
 		}
 	} else {
-		id = uuid(dataProducerPrefix)
+		id = UUID(dataProducerPrefix)
 	}
 
 	sctpStreamParameters := clone(options.SctpStreamParameters)
@@ -1121,7 +1121,7 @@ func (t *Transport) ConsumeDataContext(ctx context.Context, options *DataConsume
 		}
 	}
 
-	dataConsumerId := uuid(dataConsumerPrefix)
+	dataConsumerId := UUID(dataConsumerPrefix)
 
 	_, err = t.channel.Request(ctx, &FbsRequest.RequestT{
 		Method:    FbsRequest.MethodTRANSPORT_CONSUME_DATA,

--- a/types.go
+++ b/types.go
@@ -1,5 +1,7 @@
 package mediasoup
 
+var UUID = uuid
+
 type H = map[string]any
 
 // KeyValue represents a key-value pair.

--- a/utils.go
+++ b/utils.go
@@ -5,8 +5,22 @@ import (
 	"reflect"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/rs/xid"
+)
+
+const (
+	charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	routerPrefix       = "rt-"
+	transportPrefix    = "tr-"
+	producerPrefix     = "pr-"
+	consumerPrefix     = "co-"
+	dataProducerPrefix = "dp-"
+	dataConsumerPrefix = "dc-"
+	webRtcServerPrefix = "ws-"
+	rtpObserverPrefix  = "ro-"
 )
 
 func ref[T any](t T) *T {
@@ -66,8 +80,16 @@ func filter[Slice ~[]E, E any](s Slice, f func(E) bool) []E {
 	return results
 }
 
-func uuid() string {
-	return xid.New().String()
+func uuid(prefix string) string {
+	return prefix + xid.New().String()
+}
+
+func randString(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }
 
 func generateSsrc() uint32 {

--- a/worker.go
+++ b/worker.go
@@ -399,7 +399,7 @@ func (w *Worker) CreateWebRtcServer(options *WebRtcServerOptions) (*WebRtcServer
 func (w *Worker) CreateWebRtcServerContext(ctx context.Context, options *WebRtcServerOptions) (*WebRtcServer, error) {
 	w.logger.DebugContext(ctx, "CreateWebRtcServer()")
 
-	id := uuid(webRtcServerPrefix)
+	id := UUID(webRtcServerPrefix)
 
 	req := &FbsWorker.CreateWebRtcServerRequestT{
 		WebRtcServerId: id,
@@ -468,7 +468,7 @@ func (w *Worker) CreateRouterContext(ctx context.Context, options *RouterOptions
 		return nil, err
 	}
 
-	routerId := uuid(routerPrefix)
+	routerId := UUID(routerPrefix)
 	req := &FbsWorker.CreateRouterRequestT{
 		RouterId: routerId,
 	}

--- a/worker.go
+++ b/worker.go
@@ -364,24 +364,7 @@ func (w *Worker) GetResourceUsageContext(ctx context.Context) (usage *WorkerReso
 	}
 	resp := respAny.(*FbsWorker.ResourceUsageResponseT)
 
-	return &WorkerResourceUsage{
-		RuUtime:    resp.RuUtime,
-		RuStime:    resp.RuStime,
-		RuMaxrss:   resp.RuMaxrss,
-		RuIxrss:    resp.RuIxrss,
-		RuIdrss:    resp.RuIdrss,
-		RuIsrss:    resp.RuIsrss,
-		RuMinflt:   resp.RuMinflt,
-		RuMajflt:   resp.RuMajflt,
-		RuNswap:    resp.RuNswap,
-		RuInblock:  resp.RuInblock,
-		RuOublock:  resp.RuOublock,
-		RuMsgsnd:   resp.RuMsgsnd,
-		RuMsgrcv:   resp.RuMsgrcv,
-		RuNsignals: resp.RuNsignals,
-		RuNvcsw:    resp.RuNvcsw,
-		RuNivcsw:   resp.RuNivcsw,
-	}, nil
+	return (*WorkerResourceUsage)(resp), nil
 }
 
 // UpdateSettings updates worker settings.
@@ -416,7 +399,7 @@ func (w *Worker) CreateWebRtcServer(options *WebRtcServerOptions) (*WebRtcServer
 func (w *Worker) CreateWebRtcServerContext(ctx context.Context, options *WebRtcServerOptions) (*WebRtcServer, error) {
 	w.logger.DebugContext(ctx, "CreateWebRtcServer()")
 
-	id := uuid()
+	id := uuid(webRtcServerPrefix)
 
 	req := &FbsWorker.CreateWebRtcServerRequestT{
 		WebRtcServerId: id,
@@ -485,7 +468,7 @@ func (w *Worker) CreateRouterContext(ctx context.Context, options *RouterOptions
 		return nil, err
 	}
 
-	routerId := uuid()
+	routerId := uuid(routerPrefix)
 	req := &FbsWorker.CreateRouterRequestT{
 		RouterId: routerId,
 	}


### PR DESCRIPTION
Update UUID generation to include prefixes for better identification and replace function calls with a consistent UUID variable. Use a constant for the default handler ID in requests.