### PR TITLE
refactor: context handling

### DIFF
--- a/data_producer_test.go
+++ b/data_producer_test.go
@@ -1,9 +1,11 @@
 package mediasoup
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func createDataProducer(transport *Transport) *DataProducer {
@@ -71,10 +73,10 @@ func TestDataProducerDumpSucceeds(t *testing.T) {
 
 func TestDataProducerClose(t *testing.T) {
 	t.Run("close normally", func(t *testing.T) {
-		mock := new(MockedHandler)
-		defer mock.AssertExpectations(t)
+		mymock := new(MockedHandler)
+		defer mymock.AssertExpectations(t)
 
-		mock.On("OnClose").Times(1)
+		mymock.On("OnClose", mock.IsType(context.Background())).Once()
 
 		router := createRouter(nil)
 		transport := createDirectTransport(router)
@@ -83,7 +85,7 @@ func TestDataProducerClose(t *testing.T) {
 				StreamId: 666,
 			},
 		})
-		dataProducer.OnClose(mock.OnClose)
+		dataProducer.OnClose(mymock.OnClose)
 		err := dataProducer.Close()
 		assert.NoError(t, err)
 		assert.True(t, dataProducer.Closed())
@@ -104,10 +106,10 @@ func TestDataProducerClose(t *testing.T) {
 	})
 
 	t.Run("transport closed", func(t *testing.T) {
-		mock := new(MockedHandler)
-		defer mock.AssertExpectations(t)
+		mymock := new(MockedHandler)
+		defer mymock.AssertExpectations(t)
 
-		mock.On("OnClose").Times(1)
+		mymock.On("OnClose", mock.IsType(context.Background())).Once()
 
 		router := createRouter(nil)
 		transport := createDirectTransport(router)
@@ -116,16 +118,16 @@ func TestDataProducerClose(t *testing.T) {
 				StreamId: 666,
 			},
 		})
-		dataProducer.OnClose(mock.OnClose)
+		dataProducer.OnClose(mymock.OnClose)
 		transport.Close()
 		assert.True(t, dataProducer.Closed())
 	})
 
 	t.Run("router closed", func(t *testing.T) {
-		mock := new(MockedHandler)
-		defer mock.AssertExpectations(t)
+		mymock := new(MockedHandler)
+		defer mymock.AssertExpectations(t)
 
-		mock.On("OnClose").Times(1)
+		mymock.On("OnClose", mock.IsType(context.Background())).Once()
 
 		router := createRouter(nil)
 		transport := createDirectTransport(router)
@@ -134,7 +136,7 @@ func TestDataProducerClose(t *testing.T) {
 				StreamId: 666,
 			},
 		})
-		dataProducer.OnClose(mock.OnClose)
+		dataProducer.OnClose(mymock.OnClose)
 		router.Close()
 		assert.True(t, dataProducer.Closed())
 	})

--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -1,0 +1,62 @@
+package channel
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	FbsRequest "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/Request"
+)
+
+func getListLength(list *listNode) int {
+	if list == nil {
+		return 0
+	}
+	next := list.next
+	count := 0
+	for next != nil {
+		count++
+		next = next.next
+	}
+	return count
+}
+
+func TestSaveContext(t *testing.T) {
+	r, w, _ := os.Pipe()
+	channel := NewChannel(w, r, slog.Default())
+	defer channel.Close(context.Background())
+
+	ctx := context.WithValue(context.Background(), "key", "value")
+
+	cleanup1 := channel.maySaveContextLocked(ctx, &FbsRequest.RequestT{
+		Method:    FbsRequest.MethodPRODUCER_PAUSE,
+		HandlerId: "handlerId1",
+	})
+	cleanup2 := channel.maySaveContextLocked(ctx, &FbsRequest.RequestT{
+		Method:    FbsRequest.MethodPRODUCER_PAUSE,
+		HandlerId: "handlerId2",
+	})
+
+	origCtx := UnwrapContext(channel.getContext(methodEventMap[FbsRequest.MethodPRODUCER_PAUSE]), "handlerId1")
+	if ctx.Value("key") != origCtx.Value("key") {
+		t.Errorf("Expected context to be the same")
+	}
+
+	cleanup1()
+
+	if length := getListLength(channel.contextList); length != 1 {
+		t.Errorf("Expected list length to be 1, got %d", length)
+	}
+
+	origCtx = UnwrapContext(channel.getContext(methodEventMap[FbsRequest.MethodPRODUCER_PAUSE]), "handlerId2")
+	if ctx.Value("key") != origCtx.Value("key") {
+		t.Errorf("Expected context to be the same")
+	}
+
+	cleanup2()
+
+	if length := getListLength(channel.contextList); length != 0 {
+		t.Errorf("Expected list length to be 0, got %d", length)
+	}
+}

--- a/internal/channel/context.go
+++ b/internal/channel/context.go
@@ -1,0 +1,33 @@
+package channel
+
+import (
+	"context"
+
+	FbsNotification "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/Notification"
+)
+
+var wrappedContextKey = struct{}{}
+
+type WrappedContext struct {
+	Event     FbsNotification.Event
+	HandlerId string
+	Context   context.Context
+}
+
+func withWrappedContext(ctx context.Context, data *WrappedContext) context.Context {
+	return context.WithValue(ctx, wrappedContextKey, data)
+}
+
+func getWrappedContext(ctx context.Context) (*WrappedContext, bool) {
+	if data, ok := ctx.Value(wrappedContextKey).(*WrappedContext); ok {
+		return data, true
+	}
+	return nil, false
+}
+
+func UnwrapContext(ctx context.Context, handlerId string) context.Context {
+	if data, ok := getWrappedContext(ctx); ok && handlerId == data.HandlerId {
+		return data.Context
+	}
+	return ctx
+}

--- a/internal/channel/subscription.go
+++ b/internal/channel/subscription.go
@@ -1,16 +1,18 @@
 package channel
 
 import (
+	"context"
 	"sync"
 
 	FbsNotification "github.com/jiyeyuran/mediasoup-go/v2/internal/FBS/Notification"
 )
 
-type Handler func(event FbsNotification.Event, body *FbsNotification.BodyT)
+type Handler func(ctx context.Context, notification *FbsNotification.NotificationT)
 
 type Msg struct {
-	Data *FbsNotification.NotificationT
-	next *Msg
+	Context context.Context
+	Data    *FbsNotification.NotificationT
+	next    *Msg
 }
 
 // Subscription represents interest in a given subject.

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,6 +1,8 @@
 package mediasoup
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -8,40 +10,40 @@ type MockedHandler struct {
 	mock.Mock
 }
 
-func (m *MockedHandler) OnNewWebRtcServer(arg1 *WebRtcServer) {
-	m.Called(arg1)
+func (m *MockedHandler) OnNewWebRtcServer(ctx context.Context, arg1 *WebRtcServer) {
+	m.Called(ctx, arg1)
 }
 
-func (m *MockedHandler) OnNewRouter(arg1 *Router) {
-	m.Called(arg1)
+func (m *MockedHandler) OnNewRouter(ctx context.Context, arg1 *Router) {
+	m.Called(ctx, arg1)
 }
 
-func (m *MockedHandler) OnNewRtpObserver(arg1 *RtpObserver) {
-	m.Called(arg1)
+func (m *MockedHandler) OnNewRtpObserver(ctx context.Context, arg1 *RtpObserver) {
+	m.Called(ctx, arg1)
 }
 
-func (m *MockedHandler) OnNewTransport(arg1 *Transport) {
-	m.Called(arg1)
+func (m *MockedHandler) OnNewTransport(ctx context.Context, arg1 *Transport) {
+	m.Called(ctx, arg1)
 }
 
-func (m *MockedHandler) OnNewProducer(arg1 *Producer) {
-	m.Called(arg1)
+func (m *MockedHandler) OnNewProducer(ctx context.Context, arg1 *Producer) {
+	m.Called(ctx, arg1)
 }
 
-func (m *MockedHandler) OnNewConsumer(arg1 *Consumer) {
-	m.Called(arg1)
+func (m *MockedHandler) OnNewConsumer(ctx context.Context, arg1 *Consumer) {
+	m.Called(ctx, arg1)
 }
 
-func (m *MockedHandler) OnNewDataProducer(arg1 *DataProducer) {
-	m.Called(arg1)
+func (m *MockedHandler) OnNewDataProducer(ctx context.Context, arg1 *DataProducer) {
+	m.Called(ctx, arg1)
 }
 
-func (m *MockedHandler) OnNewDataConsumer(arg1 *DataConsumer) {
-	m.Called(arg1)
+func (m *MockedHandler) OnNewDataConsumer(ctx context.Context, arg1 *DataConsumer) {
+	m.Called(ctx, arg1)
 }
 
-func (m *MockedHandler) OnClose() {
-	m.Called()
+func (m *MockedHandler) OnClose(ctx context.Context) {
+	m.Called(ctx)
 }
 
 func (m *MockedHandler) OnProducerScore(arg1 []ProducerScore) {
@@ -56,16 +58,20 @@ func (m *MockedHandler) OnProducerEventTrace(arg1 ProducerTraceEventData) {
 	m.Called(arg1)
 }
 
-func (m *MockedHandler) OnProducerClosed() {
-	m.Called()
+func (m *MockedHandler) OnProducerClose(ctx context.Context) {
+	m.Called(ctx)
 }
 
-func (m *MockedHandler) OnProducerPause() {
-	m.Called()
+func (m *MockedHandler) OnProducerPause(ctx context.Context) {
+	m.Called(ctx)
 }
 
-func (m *MockedHandler) OnProducerResume() {
-	m.Called()
+func (m *MockedHandler) OnProducerResume(ctx context.Context) {
+	m.Called(ctx)
+}
+
+func (m *MockedHandler) OnDataProducerClose(ctx context.Context) {
+	m.Called(ctx)
 }
 
 func (m *MockedHandler) OnConsumeScore(arg1 ConsumerScore) {

--- a/router_test.go
+++ b/router_test.go
@@ -1,6 +1,7 @@
 package mediasoup
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -47,27 +48,27 @@ func createRouter(worker *Worker) *Router {
 
 func TestRouterClose(t *testing.T) {
 	t.Run("close normally", func(t *testing.T) {
-		mock := new(MockedHandler)
-		defer mock.AssertExpectations(t)
+		mymock := new(MockedHandler)
+		defer mymock.AssertExpectations(t)
 
-		mock.On("OnClose").Times(1)
+		mymock.On("OnClose", mock.IsType(context.Background())).Once()
 
 		worker := newTestWorker()
 		router, _ := worker.CreateRouter(&RouterOptions{})
-		router.OnClose(mock.OnClose)
+		router.OnClose(mymock.OnClose)
 		assert.NoError(t, router.Close())
 		assert.True(t, router.Closed())
 	})
 
 	t.Run("worker closed", func(t *testing.T) {
-		mock := new(MockedHandler)
-		defer mock.AssertExpectations(t)
+		mymock := new(MockedHandler)
+		defer mymock.AssertExpectations(t)
 
-		mock.On("OnClose").Times(1)
+		mymock.On("OnClose", mock.IsType(context.Background())).Once()
 
 		worker := newTestWorker()
 		router, _ := worker.CreateRouter(&RouterOptions{})
-		router.OnClose(mock.OnClose)
+		router.OnClose(mymock.OnClose)
 		worker.Close()
 		assert.True(t, router.Closed())
 	})
@@ -82,14 +83,14 @@ func TestRouterDump(t *testing.T) {
 }
 
 func TestCreateWebRtcTransport(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewTransport", mock.IsType(&Transport{})).Times(2)
+	mymock.On("OnNewTransport", mock.IsType(context.Background()), mock.IsType(&Transport{})).Times(2)
 
 	worker := newTestWorker()
 	router, _ := worker.CreateRouter(&RouterOptions{})
-	router.OnNewTransport(myMock.OnNewTransport)
+	router.OnNewTransport(mymock.OnNewTransport)
 	transport1, err := router.CreateWebRtcTransport(&WebRtcTransportOptions{
 		ListenInfos: []TransportListenInfo{
 			{Ip: "127.0.0.1"},
@@ -159,14 +160,14 @@ func TestCreateWebRtcTransportWithPortRange(t *testing.T) {
 }
 
 func TestCreatePlainTransport(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewTransport", mock.IsType(&Transport{})).Once()
+	mymock.On("OnNewTransport", mock.IsType(context.Background()), mock.IsType(&Transport{})).Once()
 
 	worker := newTestWorker()
 	router, _ := worker.CreateRouter(&RouterOptions{})
-	router.OnNewTransport(myMock.OnNewTransport)
+	router.OnNewTransport(mymock.OnNewTransport)
 	transport, err := router.CreatePlainTransport(&PlainTransportOptions{
 		ListenInfo: TransportListenInfo{
 			Ip: "127.0.0.1",
@@ -231,11 +232,11 @@ func TestCreatePipeTransport(t *testing.T) {
 	videoProducer.Pause()
 
 	t.Run("enable rtx", func(t *testing.T) {
-		myMock := new(MockedHandler)
-		defer myMock.AssertExpectations(t)
+		mymock := new(MockedHandler)
+		defer mymock.AssertExpectations(t)
 
-		myMock.On("OnNewTransport", mock.IsType(&Transport{}))
-		router1.OnNewTransport(myMock.OnNewTransport)
+		mymock.On("OnNewTransport", mock.IsType(context.Background()), mock.IsType(&Transport{}))
+		router1.OnNewTransport(mymock.OnNewTransport)
 
 		pipeTransport, err := router1.CreatePipeTransport(&PipeTransportOptions{
 			ListenInfo: TransportListenInfo{Ip: "127.0.0.1"},
@@ -417,14 +418,14 @@ func TestCreatePipeTransport(t *testing.T) {
 }
 
 func TestCreateDirectTransport(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewTransport", mock.IsType(&Transport{})).Once()
+	mymock.On("OnNewTransport", mock.IsType(context.Background()), mock.IsType(&Transport{})).Once()
 
 	worker := newTestWorker()
 	router, _ := worker.CreateRouter(&RouterOptions{})
-	router.OnNewTransport(myMock.OnNewTransport)
+	router.OnNewTransport(mymock.OnNewTransport)
 	transport, err := router.CreateDirectTransport(&DirectTransportOptions{})
 	require.NoError(t, err)
 	dump, _ := router.Dump()
@@ -432,14 +433,14 @@ func TestCreateDirectTransport(t *testing.T) {
 }
 
 func TestCreateActiveSpeakerObserver(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewRtpObserver", mock.IsType(&RtpObserver{})).Once()
+	mymock.On("OnNewRtpObserver", mock.IsType(context.Background()), mock.IsType(&RtpObserver{})).Once()
 
 	worker := newTestWorker()
 	router, _ := worker.CreateRouter(&RouterOptions{})
-	router.OnNewRtpObserver(myMock.OnNewRtpObserver)
+	router.OnNewRtpObserver(mymock.OnNewRtpObserver)
 	rtpObserver, err := router.CreateActiveSpeakerObserver()
 	require.NoError(t, err)
 	assert.NotEmpty(t, rtpObserver.Id())
@@ -453,14 +454,14 @@ func TestCreateActiveSpeakerObserver(t *testing.T) {
 }
 
 func TestCreateAudioLevelObserver(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewRtpObserver", mock.IsType(&RtpObserver{})).Once()
+	mymock.On("OnNewRtpObserver", mock.IsType(context.Background()), mock.IsType(&RtpObserver{})).Once()
 
 	worker := newTestWorker()
 	router, _ := worker.CreateRouter(&RouterOptions{})
-	router.OnNewRtpObserver(myMock.OnNewRtpObserver)
+	router.OnNewRtpObserver(mymock.OnNewRtpObserver)
 	rtpObserver, err := router.CreateAudioLevelObserver()
 	require.NoError(t, err)
 	assert.NotEmpty(t, rtpObserver.Id())

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,6 +1,7 @@
 package mediasoup
 
 import (
+	"context"
 	"regexp"
 	"slices"
 	"strconv"
@@ -65,7 +66,7 @@ func TestTransportClose(t *testing.T) {
 		m := MockedHandler{}
 		defer m.AssertExpectations(t)
 
-		m.On("OnClose").Times(1)
+		m.On("OnClose", mock.IsType(context.Background())).Once()
 
 		router := createRouter(newTestWorker())
 		transport := createWebRtcTransport(router)
@@ -86,7 +87,7 @@ func TestTransportClose(t *testing.T) {
 		m := MockedHandler{}
 		defer m.AssertExpectations(t)
 
-		m.On("OnClose").Times(1)
+		m.On("OnClose", mock.IsType(context.Background())).Once()
 
 		router := createRouter(newTestWorker())
 		transport := createWebRtcTransport(router)
@@ -217,14 +218,14 @@ func TestTransportEnableTraceEvent(t *testing.T) {
 }
 
 func TestTransportProduce(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewProducer", mock.IsType(&Producer{})).Times(2)
+	mymock.On("OnNewProducer", mock.IsType(context.Background()), mock.IsType(&Producer{})).Times(2)
 
 	router := createRouter(nil)
 	transport := createWebRtcTransport(router)
-	transport.OnNewProducer(myMock.OnNewProducer)
+	transport.OnNewProducer(mymock.OnNewProducer)
 	aproducer := createAudioProducer(transport)
 	vproducer := createVideoProducer(transport)
 
@@ -451,14 +452,14 @@ func TestTransportProduceError(t *testing.T) {
 }
 
 func TestTransportConsume(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewConsumer", mock.IsType(&Consumer{})).Times(3)
+	mymock.On("OnNewConsumer", mock.IsType(context.Background()), mock.IsType(&Consumer{})).Times(3)
 
 	router := createRouter(nil)
 	transport := createWebRtcTransport(router)
-	transport.OnNewConsumer(myMock.OnNewConsumer)
+	transport.OnNewConsumer(mymock.OnNewConsumer)
 	aproducer := createAudioProducer(transport)
 	aconsumer := createConsumer(transport, aproducer.Id())
 
@@ -707,17 +708,17 @@ func TestTransportConsumeUnsupportedError(t *testing.T) {
 }
 
 func TestTransportProduceData(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewDataProducer", mock.IsType(&DataProducer{})).Times(2)
+	mymock.On("OnNewDataProducer", mock.IsType(context.Background()), mock.IsType(&DataProducer{})).Times(2)
 
 	router := createRouter(newTestWorker())
 	transport1 := createWebRtcTransport(router, func(o *WebRtcTransportOptions) { o.EnableSctp = true })
 	transport2 := createPlainTransport(router, func(o *PlainTransportOptions) { o.EnableSctp = true })
 
 	for i, transport := range []*Transport{transport1, transport2} {
-		transport.OnNewDataProducer(myMock.OnNewDataProducer)
+		transport.OnNewDataProducer(mymock.OnNewDataProducer)
 		dataProducer, err := transport.ProduceData(&DataProducerOptions{
 			SctpStreamParameters: &SctpStreamParameters{StreamId: uint16(i + 1), MaxRetransmits: ref[uint16](3)},
 			Label:                "foo",
@@ -775,10 +776,10 @@ func TestTransportProduceData(t *testing.T) {
 }
 
 func TestTransportConsumeData(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewDataConsumer", mock.IsType(&DataConsumer{})).Times(2)
+	mymock.On("OnNewDataConsumer", mock.IsType(context.Background()), mock.IsType(&DataConsumer{})).Times(2)
 
 	worker := newTestWorker()
 	router1 := createRouter(worker)
@@ -790,7 +791,7 @@ func TestTransportConsumeData(t *testing.T) {
 		transport1: router1,
 		transport2: router2,
 	} {
-		transport.OnNewDataConsumer(myMock.OnNewDataConsumer)
+		transport.OnNewDataConsumer(mymock.OnNewDataConsumer)
 		dataProducer, _ := transport.ProduceData(&DataProducerOptions{
 			SctpStreamParameters: &SctpStreamParameters{
 				StreamId:          12345,

--- a/webrtc_server.go
+++ b/webrtc_server.go
@@ -95,19 +95,19 @@ func (s *WebRtcServer) CloseContext(ctx context.Context) error {
 	})
 
 	for _, transport := range transports {
-		transport.listenServerClosed()
+		transport.listenServerClosed(ctx)
 	}
 
 	return err
 }
 
 // workerClosed is called when worker was closed.
-func (s *WebRtcServer) workerClosed() {
-	s.logger.Debug("workerClosed()")
+func (s *WebRtcServer) workerClosed(ctx context.Context) {
+	s.logger.DebugContext(ctx, "workerClosed()")
 	// NOTE: No need to close WebRtcTransports since they are closed by their
 	// respective Router parents.
 	clearSyncMap(&s.webRtcTransports)
-	s.notifyClosed()
+	s.notifyClosed(ctx)
 }
 
 // Dump returns WebRtcServer information.
@@ -153,7 +153,7 @@ func (s *WebRtcServer) DumpContext(ctx context.Context) (*WebRtcServerDump, erro
 
 func (s *WebRtcServer) handleWebRtcTransport(transport *Transport) {
 	s.webRtcTransports.Store(transport.Id(), transport)
-	transport.OnClose(func() {
+	transport.OnClose(func(ctx context.Context) {
 		s.webRtcTransports.Delete(transport.Id())
 	})
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,6 +1,7 @@
 package mediasoup
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"net"
@@ -95,13 +96,13 @@ func TestWorkerUpdateSettings(t *testing.T) {
 }
 
 func TestWorkerCreateWebRtcServer(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewWebRtcServer", mock.IsType(&WebRtcServer{})).Once()
+	mymock.On("OnNewWebRtcServer", mock.IsType(context.Background()), mock.IsType(&WebRtcServer{})).Once()
 
 	worker := newTestWorker()
-	worker.OnNewWebRtcServer(myMock.OnNewWebRtcServer)
+	worker.OnNewWebRtcServer(mymock.OnNewWebRtcServer)
 	server, err := worker.CreateWebRtcServer(&WebRtcServerOptions{
 		ListenInfos: []*TransportListenInfo{
 			{Protocol: TransportProtocolUDP, Ip: "127.0.0.1", Port: pickUdpPort()},
@@ -115,13 +116,13 @@ func TestWorkerCreateWebRtcServer(t *testing.T) {
 }
 
 func TestWorkerCreateRouter(t *testing.T) {
-	myMock := new(MockedHandler)
-	defer myMock.AssertExpectations(t)
+	mymock := new(MockedHandler)
+	defer mymock.AssertExpectations(t)
 
-	myMock.On("OnNewRouter", mock.IsType(&Router{})).Times(2)
+	mymock.On("OnNewRouter", mock.IsType(context.Background()), mock.IsType(&Router{})).Times(2)
 
 	worker := newTestWorker()
-	worker.OnNewRouter(myMock.OnNewRouter)
+	worker.OnNewRouter(mymock.OnNewRouter)
 	router, err := worker.CreateRouter(&RouterOptions{
 		MediaCodecs: []*RtpCodecCapability{
 			{


### PR DESCRIPTION
- Updated handler signatures to accept context.Context in various methods across Transport, RtpObserver, Router, and Worker.
- Modified test cases to align with the new context-aware handlers.
- Ensured proper context propagation during close operations and event notifications.
- Enhanced logging to include context information for better traceability.