### PR TITLE
feat(worker): add support for built-in SCTP stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        worker_version: ["3.19.18", "3.19.20"]
+        worker_version: ["3.19.18", "3.19.21"]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        worker_version: ["3.19.18", "3.19.19"]
+        worker_version: ["3.19.18", "3.19.20"]
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+### 2.4.1
+
+- Worker: Add `UseBuiltInSctpStack` setting (defaults to `false`) to enable mediasoup built-in SCTP stack
+
 ### 2.4.0
+
 - Convert WORKER_CLOSE into a notification
 
 ### 2.3.3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The following table shows which mediasoup versions are supported by each mediaso
 
 | mediasoup-go version | Supported mediasoup version |
 | -------------------- | --------------------------- |
-| v2.4.x               | v3.19.18~v3.19.20           |
+| v2.4.x               | v3.19.18~v3.19.21           |
 | v2.3.x               | v3.19.14~v3.19.17           |
 | v2.2.0               | v3.17.0                     |
 | v2.0.0~v2.2.0        | v3.14.0~v3.17.0             |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The following table shows which mediasoup versions are supported by each mediaso
 
 | mediasoup-go version | Supported mediasoup version |
 | -------------------- | --------------------------- |
-| v2.4.x               | v3.19.18~v3.19.19           |
+| v2.4.x               | v3.19.18~v3.19.20           |
 | v2.3.x               | v3.19.14~v3.19.17           |
 | v2.2.0               | v3.17.0                     |
 | v2.0.0~v2.2.0        | v3.14.0~v3.17.0             |

--- a/sctp_parameters.go
+++ b/sctp_parameters.go
@@ -11,21 +11,10 @@ type SctpCapabilities struct {
 // (to be used by DataConsumers), while MIS refers to the maximum int of
 // incoming SCTP streams that the server side transport can receive (to be used
 // by DataProducers). So, if the server side transport will just be used to
-// create data producers (but no data consumers), OS can be low (~1). However,
-// if data consumers are desired on the server side transport, OS must have a
-// proper value and such a proper value depends on whether the remote endpoint
-// supports  SCTP_ADD_STREAMS extension or not.
-//
-// libwebrtc (Chrome, Safari, etc) does not enable SCTP_ADD_STREAMS so, if data
-// consumers are required,  OS should be 1024 (the maximum int of DataChannels
-// that libwebrtc enables).
-//
-// Firefox does enable SCTP_ADD_STREAMS so, if data consumers are required, OS
-// can be lower (16 for instance). The mediasoup transport will allocate and
-// announce more outgoing SCTM streams when needed.
-//
+// create data producers (but no data consumers), OS can be low (~1).
 // mediasoup-client provides specific per browser/version OS and MIS values via
-// the device.sctpCapabilities getter.
+// the device.sctpCapabilities getter. However those values must be reversed
+// when provided to the mediasoup server transport.
 type NumSctpStreams struct {
 	// OS defines initially requested int of outgoing SCTP streams.
 	OS uint16 `json:"OS,omitempty"`

--- a/worker.go
+++ b/worker.go
@@ -25,7 +25,7 @@ import (
 )
 
 // MEDIASOUP_WORKER_VERSION is the maximum supported version of the mediasoup C++ subprocess.
-const MEDIASOUP_WORKER_VERSION = "3.19.20"
+const MEDIASOUP_WORKER_VERSION = "3.19.21"
 
 // Worker represents a mediasoup C++ subprocess that runs in a single CPU core and handles Router
 // instances.

--- a/worker.go
+++ b/worker.go
@@ -25,7 +25,7 @@ import (
 )
 
 // MEDIASOUP_WORKER_VERSION is the maximum supported version of the mediasoup C++ subprocess.
-const MEDIASOUP_WORKER_VERSION = "3.19.19"
+const MEDIASOUP_WORKER_VERSION = "3.19.20"
 
 // Worker represents a mediasoup C++ subprocess that runs in a single CPU core and handles Router
 // instances.
@@ -136,6 +136,10 @@ func NewWorker(workerBinaryPath string, options ...Option) (*Worker, error) {
 
 	if opts.DisableLiburing {
 		args = append(args, "--disableLiburing=true")
+	}
+
+	if opts.UseBuiltInSctpStack {
+		args = append(args, "--useBuiltInSctpStack=true")
 	}
 
 	logger.Debug(fmt.Sprintf("starting worker process: %s %s", workerBinaryPath, strings.Join(args, " ")))

--- a/worker_types.go
+++ b/worker_types.go
@@ -56,6 +56,10 @@ type WorkerSettings struct {
 	// DisableLiburing disables io_uring even if supported by host.
 	DisableLiburing bool `json:"disableLiburing,omitempty"`
 
+	// UseBuiltInSctpStack sets whether to use the mediasoup built-in SCTP stack
+	// instead usrsctp.
+	UseBuiltInSctpStack bool `json:"useBuiltInSctpStack,omitempty"`
+
 	// AppData holds custom application data.
 	AppData H `json:"appData,omitempty"`
 


### PR DESCRIPTION
Add `UseBuiltInSctpStack` setting to enable mediasoup's built-in SCTP stack as an alternative to usrsctp. Update supported mediasoup version to v3.19.20.